### PR TITLE
bugfix remove control_node_serial_interface from setup.py SCRIPTS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ def get_version(package):
 
 
 SCRIPTS = glob('bin/scripts/*')
-SCRIPTS += ['control_node_serial/control_node_serial_interface']
 
 INSTALL_REQUIRES = ['argparse', 'bottle', 'paste', 'pyserial']
 INSTALL_REQUIRES += ['pyelftools']
@@ -186,7 +185,7 @@ setup(name=PACKAGE,
 
       scripts=SCRIPTS,
       include_package_data=True,
-      package_data={'static': ['static/*']},
+      package_data={'static': ['static/*'],'control_node_serial_interface':'control_node_serial/control_node_serial_interface'},
       ext_modules=[Extension('control_node_serial_interface', [])],
 
       cmdclass={


### PR DESCRIPTION
Right now, setup.py tries to read control_node_serial_interface (a binary) as text, this breaks ```python setup.py develop```