### PR TITLE
codecov 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,15 @@ before_install:
   - if [ -e docker/previous_image.tar.gz ]; then docker load -i docker/previous_image.tar.gz; fi
 
 install:
+  - ci_env=`bash <(curl -s https://codecov.io/env)`
   - docker build -t iot-lab-gateway --cache-from=iot-lab-gateway .
   - docker build -t iot-lab-gateway-tests tests
 
 before_cache:
   - docker save -o docker/previous_image.tar.gz iot-lab-gateway
 
+after_success:
+  - docker run -v $PWD:/home/iot-lab-gateway $ci_env --privileged iot-lab-gateway-tests tox -e upload_coverage
+
 script:
-  - docker run -t iot-lab-gateway-tests tox
+  - docker run -v $PWD:/home/iot-lab-gateway -t iot-lab-gateway-tests tox

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "control_node_serial/tests/utils"
+comment: false

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -21,7 +21,7 @@ FROM iot-lab-gateway
 
 # Update
 RUN apt-get update && \
-    apt-get install -y python-pip gdb
+    apt-get install -y python-pip valgrind gdb
 
 # Install app dependencies
 RUN pip install --upgrade pip && \

--- a/tests_utils/check_license.sh
+++ b/tests_utils/check_license.sh
@@ -15,6 +15,7 @@ files_list=$(echo "${files_list}" | grep -v \
     -e '.elf' \
     -e '.hex' \
     -e '.travis.yml' \
+    -e 'codecov.yml' \
     -e 'Dockerfile' \
     -e 'node.z1' \
     -e '.json'\

--- a/tests_utils/test-requirements.txt
+++ b/tests_utils/test-requirements.txt
@@ -8,3 +8,4 @@ nosexcover
 mock
 WebTest
 testfixtures
+codecov>=1.4.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = copying, test, code_check
+envlist = copying, test, code_check, control_node_serial
 
 # infos:
 #   can't hide return value before tox 1.9
@@ -13,6 +13,12 @@ passenv = IOTLAB_GATEWAY_CFG_DIR
 deps = -rtests_utils/test-requirements.txt
 commands =
     python setup.py nosetests {posargs}
+
+
+[testenv:upload_coverage]
+deps = -rtests_utils/test-requirements.txt
+passenv = CI TRAVIS TRAVIS_*
+commands = codecov
 
 
 [testenv:copying]


### PR DESCRIPTION
codecov is run inside the tests docker container

we use tox as ENTRYPOINT in the tests docker container

tested working on my fork https://codecov.io/gh/rienafairefr/iot-lab-gateway/branch/codecov

There is still some issue about getting the coverage for the control_node_serial (the C code that interfaces with the control node) probably to do with relative/absolute paths