### PR TITLE
Fix integration tests

### DIFF
--- a/gateway_code/integration/integration_tests.py
+++ b/gateway_code/integration/integration_tests.py
@@ -30,6 +30,7 @@ import time
 import math
 import subprocess
 import logging
+import unittest
 from threading import Thread
 from itertools import izip
 
@@ -372,6 +373,7 @@ class TestComplexExperimentRunning(ExperimentRunningMock):
             except IOError:
                 self.fail('File should exist %r' % exp_files[meas_type])
 
+    @class_attr_has(CN_FEATURES_ATTR, 'consumption')
     def test_exp_with_fastest_measures(self):
         """ Run an experiment with fastest measures."""
 

--- a/gateway_code/integration/integration_tests.py
+++ b/gateway_code/integration/integration_tests.py
@@ -30,7 +30,6 @@ import time
 import math
 import subprocess
 import logging
-import unittest
 from threading import Thread
 from itertools import izip
 

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -23,6 +23,9 @@ FROM iot-lab-gateway
 RUN apt-get update
 RUN apt-get install -y python-pip
 
+RUN apt-get update && \
+    apt-get install -y gdb
+
 # Install app dependencies
 RUN pip install --upgrade pip
 


### PR DESCRIPTION
With these fixes, integration tests are working on a normal laptop using the docker image.

On a normal host (assuming your laptop has an M3 plugged in):

docker run -t -v /dev/ttyON_M3:/dev/ttyON_M3 -v $PWD:/home/iot-lab-gateway -v $PWD/tests_utils/cfg_dir:/var/local/config -e BOARD_TYPE=m3 -e CONTROL_NODE_TYPE=no -e HOSTNAME=m3-00 -e IOTLAB_GATEWAY_CFG_DIR=/var/local/config --privileged iot-lab-gateway-test tox