### PR TITLE
gateway: make openocd program path configurable for open nodes

### DIFF
--- a/gateway_code/open_nodes/node_samr21.py
+++ b/gateway_code/open_nodes/node_samr21.py
@@ -40,7 +40,6 @@ class NodeSamr21(object):
     TTY = '/dev/ttyON_SAMR21'
     BAUDRATE = 115200
     OPENOCD_CFG_FILE = static_path('iot-lab-samr21.cfg')
-    OPENOCD_OPTS = ()
     FW_IDLE = static_path('samr21_idle.elf')
     FW_AUTOTEST = static_path('samr21_autotest.elf')
 

--- a/gateway_code/utils/tests/openocd_test.py
+++ b/gateway_code/utils/tests/openocd_test.py
@@ -32,6 +32,7 @@ import unittest
 import mock
 
 from gateway_code.open_nodes.node_m3 import NodeM3  # config file
+from gateway_code.utils.openocd import OpenOCDArgs
 from .. import openocd
 
 
@@ -134,8 +135,15 @@ class TestsCall(unittest.TestCase):
 
 class TestsFlashInvalidPaths(unittest.TestCase):
     def test_invalid_config_file_path(self):
-        self.assertRaises(IOError, openocd.OpenOCD, '/invalid/path')
+        self.assertRaises(IOError, openocd.OpenOCD,
+                          OpenOCDArgs('openocd', '/invalid/path', ()))
+
+    def test_invalid_openocd_path(self):
+        self.assertRaises(IOError, openocd.OpenOCD,
+                          OpenOCDArgs('/wrong/openocd', '/invalid/path', ()))
 
     def test_invalid_firmware_path(self):
-        ret = openocd.OpenOCD(NodeM3.OPENOCD_CFG_FILE).flash('/invalid/path')
+        ret = openocd.OpenOCD(
+            OpenOCDArgs('openocd', NodeM3.OPENOCD_CFG_FILE, ())
+        ).flash('/invalid/path')
         self.assertNotEqual(0, ret)


### PR DESCRIPTION
The idea behind this PR is to give the possibility to configure the path of the openocd used to flash an open node.
New Yocto images for IoT-Lab have openocd 0.10 installed in `/opt/openocd-0.10.0/bin/openocd` so the idea is to have an optional option that can be defined in the open node class:
```python
OPENOCD_PATH = '/opt/openocd-0.10.0/bin/openocd'
```

The default is simply "openocd" as before.

I also applied the optional strategy to `OPENOCD_OPTS` attribute since it's only used for samr21 open nodes.

The integration tests still pass locally on an M3.