### PR TITLE
IOTLABGATEWAY_CFG_DIR fix

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,9 @@ deps = -rtests_utils/test-requirements.txt
 whitelist_externals =
     /bin/bash
 commands =
-    bash -c "export IOTLAB_GATEWAY_CFG_DIR={posargs:tests_utils/cfg_dir/}; \
+    bash -c "if [ -z '$IOTLAB_GATEWAY_CFG_DIR' ]; then \
+             export IOTLAB_GATEWAY_CFG_DIR={posargs:tests_utils/cfg_dir/}; \
+             fi; \
              export IOTLAB_USERS=/tmp/users;\
              python setup.py nosetests --stop"
 


### PR DESCRIPTION
in order to test with tox -e local with non m3 boards, it's necessary to keep the IOTLABGATEWAY_CFG_DIR to pass it to the tox env instead of overriding with tests_utils/cfg_dir 
This is a temporary hack. This is not necessary once the dependency injection PR is merged