### PR TITLE
opennode/arduino-zero: update node type string

### DIFF
--- a/gateway_code/open_nodes/__init__.py
+++ b/gateway_code/open_nodes/__init__.py
@@ -37,7 +37,8 @@ def node_class(board_type):
     :raises ValueError: if board class can't be found """
     try:
         module_path = '%s.%s' % (
-            __name__, OPEN_NODES_MODULE.format(type=board_type))
+            __name__, OPEN_NODES_MODULE.format(
+                type=board_type.replace('-', '_')))
         class_name = OPEN_CLASS_NAME.format(title=_node_title(board_type))
 
         # Get node class from board_type
@@ -59,10 +60,12 @@ def _node_title(board_type):
     'M3'
     >>> _node_title('arduino_zero')
     'ArduinoZero'
+    >>> _node_title('arduino-zero')
+    'ArduinoZero'
     >>> _node_title('samr21')
     'Samr21'
     """
-    return board_type.title().replace('_', '')
+    return board_type.title().replace('_', '').replace('-', '')
 
 
 def _assert_class_valid(board_class, board_type):

--- a/gateway_code/open_nodes/node_arduino_zero.py
+++ b/gateway_code/open_nodes/node_arduino_zero.py
@@ -35,7 +35,7 @@ LOGGER = logging.getLogger('gateway_code')
 class NodeArduinoZero(object):
     """ Open node Arduino Zero implementation """
 
-    TYPE = 'arduino-zero'
+    TYPE = 'arduino_zero'
     ELF_TARGET = ('ELFCLASS32', 'EM_ARM')
     TTY = '/dev/ttyON_ARDUINO_ZERO'
     BAUDRATE = 115200

--- a/gateway_code/open_nodes/node_arduino_zero.py
+++ b/gateway_code/open_nodes/node_arduino_zero.py
@@ -35,7 +35,7 @@ LOGGER = logging.getLogger('gateway_code')
 class NodeArduinoZero(object):
     """ Open node Arduino Zero implementation """
 
-    TYPE = 'arduino_zero'
+    TYPE = 'arduino-zero'
     ELF_TARGET = ('ELFCLASS32', 'EM_ARM')
     TTY = '/dev/ttyON_ARDUINO_ZERO'
     BAUDRATE = 115200


### PR DESCRIPTION
As discussed in https://github.com/iot-lab/iot-lab-dev/pull/28, I'm renaming the node type to `arduino-zero`, it will be nicer for users to use `arduino-zero-1` instead of `arduino_zero-1`