### PR TITLE
firefly bug with tty case

### DIFF
--- a/bin/rules.d/firefly.rules
+++ b/bin/rules.d/firefly.rules
@@ -1,2 +1,2 @@
 # open nodes firefly
-KERNEL=="ttyUSB*" , SUBSYSTEMS=="usb", ATTRS{idVendor}=="10c4" , ATTRS{idProduct}=="ea60" , ATTRS{product}=="Zolertia Firefly platform" , MODE="0664", GROUP="dialout", SYMLINK+="ttyON_firefly"
+KERNEL=="ttyUSB*" , SUBSYSTEMS=="usb", ATTRS{idVendor}=="10c4" , ATTRS{idProduct}=="ea60" , ATTRS{product}=="Zolertia Firefly platform" , MODE="0664", GROUP="dialout", SYMLINK+="ttyON_FIREFLY"

--- a/gateway_code/open_nodes/node_firefly.py
+++ b/gateway_code/open_nodes/node_firefly.py
@@ -37,7 +37,7 @@ class NodeFirefly(object):
     TYPE = 'firefly'
     ELF_TARGET = ('ELFCLASS32', 'EM_ARM')
 
-    TTY = '/dev/ttyON_firefly'
+    TTY = '/dev/ttyON_FIREFLY'
     # The tty as named in the udev rule
     BAUDRATE = 115200
     PROGRAM_BAUDRATE = 460800


### PR DESCRIPTION
The firefly support was not following the ttyON_NODENAME convention