### PR TITLE
.idea gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ cover
 .eggs
 # ignore the folder where we store docker images for caching in travis
 docker/
+# pycharm
+.idea/


### PR DESCRIPTION
Sorry the .idea/ litters the gitignore in multiple repos, but it's a directory that is used by pycharm