### PR TITLE
Release

### DIFF
--- a/gateway_code/control_node/cn_interface.py
+++ b/gateway_code/control_node/cn_interface.py
@@ -38,7 +38,8 @@ from gateway_code.utils import subprocess_timeout
 LOGGER = logging.getLogger('gateway_code')
 
 
-CONTROL_NODE_SERIAL_INTERFACE = 'control_node_serial_interface'
+CONTROL_NODE_SERIAL_INTERFACE = ('control_node_serial/' 
+                                 'control_node_serial_interface') 
 
 
 OML_XML = '''

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ deps = WebTest
 sitepackages = True
 commands =
     # Tests should be run as user 'www-data'
-    bash -c "test $USER == www-data"
+    bash -c "test {env:USER} == www-data"
     bash -c "python setup.py nosetests --stop \
              --xcoverage-file=$(hostname)_coverage.xml \
              --xunit-file=$(hostname)_nosetests.xml {posargs}"


### PR DESCRIPTION
I don't know why this stopped working but using tox {env:KEY} instead of the $KEY seems to work.

The control_node_serial/control_node_serial_interface path was also bad. Merging master will conflict if I add that, but without it the tests fail. Not sure what's best