### PR TITLE
fix USER env not working ?

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ deps = WebTest
 sitepackages = True
 commands =
     # Tests should be run as user 'www-data'
-    bash -c "test $USER == www-data"
+    bash -c "test {env:USER} == www-data"
     bash -c "python setup.py nosetests --stop \
              --xcoverage-file=$(hostname)_coverage.xml \
              --xunit-file=$(hostname)_nosetests.xml {posargs}"


### PR DESCRIPTION
I don't know why this stopped working but using tox {env:KEY} instead of the $KEY seems to work.