### PR TITLE
Small tox.ini changes

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,7 @@ commands =
              export IOTLAB_GATEWAY_CFG_DIR={posargs:tests_utils/cfg_dir/}; \
              fi; \
              export IOTLAB_USERS=/tmp/users;\
-             python setup.py nosetests --stop"
+             python setup.py nosetests --stop {posargs}"
 
 
 [testenv:control_node_serial]

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ commands=
 
 
 [testenv:code_check]
+skipsdist = True
 whitelist_externals = /bin/bash
 deps = -rtests_utils/test-requirements.txt
 commands =


### PR DESCRIPTION
1. skip the sdist install for code_check
2. pass posargs to the local environement, like the integration environement