### PR TITLE
serial_redirection: add named option for setting a custom start delay

### DIFF
--- a/gateway_code/utils/serial_redirection.py
+++ b/gateway_code/utils/serial_redirection.py
@@ -67,13 +67,15 @@ class SerialRedirection(threading.Thread):
         super(SerialRedirection, self).__init__(target=self._target)
         self.daemon = True
 
-    def start(self):
+    def start(self, delay=0):
         """ Start the serial redirection Thread """
         self._run = True
         LOGGER.debug('SerialRedirection start')
         super(SerialRedirection, self).start()
         # wait for 'Popen' to have been called
-        return 0 if self._started.wait(15.0) else 1
+        ret = 0 if self._started.wait(15.0) else 1
+        time.sleep(delay)
+        return ret
 
     def stop(self):
         """ Stop the running thread """


### PR DESCRIPTION
This PR is an alternative to https://github.com/schrein/iot-lab-gateway/pull/2 and https://github.com/schrein/iot-lab-gateway/pull/3

It doesn't change the behaviour of existing open nodes and is easy to adapt for Zigduino for example: just call `ret_val += self.serial_redirection.start(start_delay=2)` [here](https://github.com/iot-lab/iot-lab-gateway/blob/master/gateway_code/open_nodes/node_zigduino.py#L74).