### PR TITLE
Various fixes with node names/types containing '-'

### DIFF
--- a/gateway_code/config.py
+++ b/gateway_code/config.py
@@ -122,7 +122,7 @@ def read_config(key, default=IOError):
 
     try:
         with open(entry) as _conf:
-            return _conf.read().strip().lower()
+            return _conf.read().strip().lower().replace('-', '_')
     except IOError:
         if default is IOError:  # not provided
             raise

--- a/gateway_code/control_nodes/cn_iotlab/cn_protocol.py
+++ b/gateway_code/control_nodes/cn_iotlab/cn_protocol.py
@@ -66,7 +66,11 @@ class Protocol(object):
 
         >>> Protocol._set_node_id_args('arduino-zero-2')
         ('arduino-zero', '2')
+
+        >>> Protocol._set_node_id_args('arduino_zero_1')
+        ('arduino-zero', '1')
         """
+        node_id = node_id.replace('_', '-')
         archi = '-'.join(node_id.split('-')[:-1])
         num = str(int(node_id.split('-')[-1]))
         return archi, num

--- a/gateway_code/control_nodes/cn_iotlab/cn_protocol.py
+++ b/gateway_code/control_nodes/cn_iotlab/cn_protocol.py
@@ -61,11 +61,14 @@ class Protocol(object):
         >>> Protocol._set_node_id_args('a8-256')
         ('a8', '256')
 
-        >>> Protocol._set_node_id_args('m3-00-ci')
+        >>> Protocol._set_node_id_args('m3-00')
         ('m3', '0')
+
+        >>> Protocol._set_node_id_args('arduino-zero-2')
+        ('arduino-zero', '2')
         """
-        archi, num_str = node_id.split('-')[0:2]
-        num = str(int(num_str))
+        archi = '-'.join(node_id.split('-')[:-1])
+        num = str(int(node_id.split('-')[-1]))
         return archi, num
 
     def set_node_id(self, node_id):


### PR DESCRIPTION
This PR fixes the way the control nodes determines the node archi and num from the hostname (written in /var/local/config).

This PR also proposes a fix when the board type contains a '-' instead of '_'.

This problem happened with arduino-zero-x nodes available in Saclay site.