### PR TITLE
update setuptools for installing pyocd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,7 +122,8 @@ RUN git clone https://github.com/JelmerT/cc2538-bsl && \
     pip install intelhex
 
 # pyOCD for micro:bit
-RUN pip install pyOCD
+RUN pip install -U pip setuptools && \
+    pip install pyOCD
 
 WORKDIR /setup_dir
 COPY . /setup_dir/


### PR DESCRIPTION
A recent upgrade of pyOCD or setuptools-scm or whatever broke something, we need to self-update pip and setuptools before installing pyOCD (the apt packaged ubuntu 14.04 version of setuptools is ancient). This failure was hidden by the docker cache mechanism in travis