### PR TITLE
integration_tests: skip no log error check for nodes with dirty serial

### DIFF
--- a/gateway_code/integration/integration_test.py
+++ b/gateway_code/integration/integration_test.py
@@ -158,6 +158,11 @@ class TestComplexExperimentRunning(ExperimentRunningMock):
 
         time.sleep(1)  # wait firmware started
 
+        # Some node can leave their serial port dirty (st-lrwan1 for example)
+        if hasattr(board_class, "DIRTY_SERIAL") and board_class.DIRTY_SERIAL:
+            # Clear log error
+            self.log_error.clear()
+
         # No log error
         self.log_error.check()
 

--- a/gateway_code/open_nodes/node_st_lrwan1.py
+++ b/gateway_code/open_nodes/node_st_lrwan1.py
@@ -44,6 +44,7 @@ class NodeStLrwan1(object):
     OPENOCD_PATH = '/opt/openocd-0.10.0/bin/openocd'
     FW_IDLE = static_path('st_lrwan1_idle.elf')
     FW_AUTOTEST = static_path('st_lrwan1_autotest.elf')
+    DIRTY_SERIAL = True
 
     AUTOTEST_AVAILABLE = [
         'echo', 'get_time',  # mandatory


### PR DESCRIPTION
This PR provides a way to skip the no error check on serial for nodes that can sometimes have remaining data on the serial link.
This is typically the case for the ST-LRWAN1 node. Keeping this check is problematic since the CI fails otherwise. Here I suspect a more deep problem with the autotest firmware: the RIOT UART driver for stm32l0 could have a potential bug during initialization.

The proposed solution will just skip this check if the DIRTY_SERIAL attribute is set for a given open node. Tested on devsaclay and works.