### PR TITLE
Fix issue with nodes flashed with edbg and debugging sessions

### DIFF
--- a/gateway_code/integration/integration_test.py
+++ b/gateway_code/integration/integration_test.py
@@ -242,11 +242,15 @@ class TestComplexExperimentRunning(ExperimentRunningMock):
         ret = self._flash()
         self.assertNotEquals(0, ret.json['ret'])
 
-        # No flash, Autotest fw should be still be running
+        # No flash, Autotest fw should be still running
         self._check_node_echo(echo=True)
 
         # Stop debugger
         ret = self.server.put('/open/debug/stop')
+        self.assertEquals(0, ret.json['ret'])
+
+        # Make sure the node can be reflashed after debug session is done
+        ret = self._flash()
         self.assertEquals(0, ret.json['ret'])
 
     def test_m3_exp_invalid_fw_target(self):


### PR DESCRIPTION
This PR provides a fix for SAMR21 and Arduino-Zero that doesn't work correctly when the user start a debugging session on them.
The problem started when the Edbg flasher tool was introduced: when the node is flashed with Edbg, any attempt to flash it via a GDB session (via openocd) after leave the node in a broken state.
But it works when the node was initially flashed with openocd.

So the fix here consists in tracking the current firmware that is running on the node at the beginning of the debugging session and reflash it with openocd before opening gdb.

The other solution is to drop edbg as flashing tool and use openocd instead but in this case, the flash procedure will become a lot slower.

Tested on CI node samr21 and arduino zero and all integration tests passed.