### PR TITLE
travis: fix code coverage report with codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ before_install:
   - if [ -e docker/previous_image.tar.gz ]; then docker load -i docker/previous_image.tar.gz; fi
 
 install:
-  - ci_env=`bash <(curl -s https://codecov.io/env)`
   - docker build -t iot-lab-gateway --cache-from=iot-lab-gateway .
   - docker build -t iot-lab-gateway-tests tests
 
@@ -21,6 +20,7 @@ before_cache:
   - docker save -o docker/previous_image.tar.gz iot-lab-gateway
 
 after_success:
-  - docker run -v $PWD:/shared $ci_env iot-lab-gateway-tests tox -e upload_coverage
+  - ci_env=`bash <(curl -s https://codecov.io/env)`
+  - docker run -v $PWD:/shared -e LOCAL_USER_ID=`id -u $(USER)` $ci_env iot-lab-gateway-tests tox -e upload_coverage
 
 script: make test


### PR DESCRIPTION
This PR is an attempt to fix codecov report. Apparently it fails because of unsufficient read rights in the container. The fix consists in using the Travis user right in the container the same way it's done when running the tests.