### PR TITLE
tox: use sitepackages when running integration tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,6 @@ addopts =
     -v
     --doctest-glob="doc/*.rst"
     --doctest-modules
-    --pep8
     --cov=gateway_code
     --cov-report=xml
     --cov-report=term

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,8 @@ sitepackages = True
 commands =
     # Tests should be run as user 'www-data'
     bash -c "test {env:USER} == www-data"
-    bash -c "pytest -s -x {posargs}"
+    bash -c "python setup.py build_ext"  # build control_node_serial
+    bash -c "pytest -s -x {posargs}"     # run the full test suite
     # Get rid of pytest ImportMismatchError for future runs (either locally
     # or via docker)
     make clean-test-files

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ commands =
 whitelist_externals =
     /bin/bash
     /usr/bin/make
-deps = -rtests_utils/test-requirements.txt
+sitepackages = True
 commands =
     # Tests should be run as user 'www-data'
     bash -c "test {env:USER} == www-data"

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ whitelist_externals =
     /usr/bin/make
 deps = -rtests_utils/test-requirements.txt
 commands =
-    pytest {posargs}
+    pytest --pep8 {posargs}
     # Get rid of pytest ImportMismatchError for future runs (either locally
     # or via docker)
     make clean-test-files
@@ -65,7 +65,7 @@ commands =
              export IOTLAB_GATEWAY_CFG_DIR={posargs:tests_utils/cfg_dir/}; \
              fi; \
              export IOTLAB_USERS=/tmp/users;\
-             pytest -x"
+             pytest --pep8 -x"
     # Get rid of pytest ImportMismatchError for future runs (either locally
     # or via docker)
     make clean-test-files


### PR DESCRIPTION
This PR revert the use of dependencies from sitepackages when running the integration tests on a gateway. This PR now also makes use of WebTest from sitepackages instead of installing it in the tox environment.

**Warning:** this PR requires https://github.com/iot-lab/iot-lab-yocto/pull/19 to be merged and deployed on CI images first.

Since `pytest-pep8` is not packaged in the yocto image (do we want this ?), the `--pep8` option has been removed from the setup.cfg and is now passed explicitly to pytest when required.