### PR TITLE
node_open_node, might be used in the Cube

### DIFF
--- a/gateway_code/open_nodes/node_open_node.py
+++ b/gateway_code/open_nodes/node_open_node.py
@@ -1,0 +1,67 @@
+# -*- coding:utf-8 -*-
+
+# This file is a part of IoT-LAB gateway_code
+# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Contributor(s) : see AUTHORS file
+#
+# This software is governed by the CeCILL license under French law
+# and abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# http://www.cecill.info.
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+""" contains an implementation of The Zolertia Firefly open node"""
+
+import logging
+from glob import glob
+
+from gateway_code.autotest.autotest import FatalError
+from gateway_code.open_nodes import all_nodes_types, node_class
+
+
+LOGGER = logging.getLogger('gateway_code')
+
+
+def actual_board():
+    boards = {
+        board_type: node_class(board_type) for board_type in all_nodes_types()
+    }
+    tty_files = glob('/dev/iotlab/*')
+    if len(tty_files) != 1:
+        LOGGER.error('Cant decide what board to use, it seems '
+                     'like multiple boards are plugged')
+        LOGGER.error('TTY files : [' + ','.join(tty_files)+']')
+        raise FatalError('open_node can\'t decide a board to use')
+    tty_file = tty_files[0]
+    for board, board_class in boards.items():
+        if board_class.TTY == tty_file:
+            return board_class
+    error_msg = 'TTY %s not recognized as an implemented board TTY'
+    raise FatalError(error_msg % tty_file)
+
+
+class NodeOpenNode(object):
+    """
+    Open node that actually decides at runtime what its config is
+    This class reads the file, if present, in /dev/iotlab/tty* to decide
+    """
+
+    TYPE = 'open_node'
+
+    def __new__(cls, *args, **kwargs):
+        # Hijack the __new__, return an instance of the detected board's class
+        board = actual_board()
+        return board.__new__(board, *args, **kwargs)
+
+    # stubs, just to survice the node_class('open_node') call
+    AUTOTEST_AVAILABLE = ['echo', 'get_time']
+    ELF_TARGET = ('ELFCLASS32', 'EM_ARM')
+    TTY = 'no board detected yet'

--- a/gateway_code/open_nodes/tests/open_nodes_test.py
+++ b/gateway_code/open_nodes/tests/open_nodes_test.py
@@ -23,9 +23,13 @@
 import unittest
 import mock
 
+from gateway_code.autotest.autotest import FatalError
+from gateway_code.open_nodes.node_open_node import NodeOpenNode
 from .. import node_class, all_nodes_types
 from ..node_m3 import NodeM3
 from ..node_a8 import NodeA8
+
+GLOB = 'gateway_code.open_nodes.node_open_node.glob'
 
 
 class TestsOpenNodes(unittest.TestCase):
@@ -49,6 +53,49 @@ class TestsOpenNodes(unittest.TestCase):
             self.assertRaisesRegexp(
                 ValueError, '^Board m3 not implemented: AttributeError.*$',
                 node_class, 'm3')
+
+    @mock.patch(GLOB, mock.Mock(return_value=['too', 'many', 'dev', 'tty']))
+    def test_open_node_board_too_many(self):
+        # too many TTY in /dev/iotlab folder
+        self.assertRaises(FatalError, lambda: NodeOpenNode())
+
+    @mock.patch(GLOB, mock.Mock(return_value=[]))
+    def test_open_node_board_not_enough(self):
+        # not enough tty in /dev/iotlab
+        self.assertRaises(FatalError, lambda: NodeOpenNode())
+
+    @mock.patch(GLOB, mock.Mock(return_value=['/dev/iotlab/ttyUNRECOGNIZED']))
+    def test_open_node_board_unrecognized(self):
+        # unrecognized tty
+        self.assertRaises(FatalError, lambda: NodeOpenNode())
+
+    def test_open_node_board_class(self):
+        # node_class works for open_node
+        board_class = node_class('open_node')
+        assert board_class == NodeOpenNode
+
+    @mock.patch('gateway_code.open_nodes.node_open_node.node_class')
+    @mock.patch('gateway_code.open_nodes.node_open_node.all_nodes_types')
+    def test_open_node_board_hijack(self, all_nodes_types, node_class):
+        # tests that the hijack works
+        assert NodeOpenNode.TTY == 'no board detected yet'
+
+        class MyBoard(object):
+            TTY = 'myTTY'
+
+        all_nodes_types.return_value = ['my_board']
+
+        def fake_node_class(value):
+            return MyBoard
+
+        node_class.side_effect = fake_node_class
+
+        with mock.patch(GLOB, return_value=[MyBoard.TTY]):
+
+            node = NodeOpenNode()
+
+            assert node.__class__ == MyBoard
+            assert node.TTY == MyBoard.TTY
 
 
 class TestsOpenNodesImplementations(unittest.TestCase):


### PR DESCRIPTION
This is a special kind of open node: this is the python code corresponding to the `open_node` board type, this board type will check which /dev/iotlab/ttyON_* is currently attached to the board, and use the right Node* class. 
This will enable scenarios in the Cube where plug in plug out without having to start a fabric rule or mess up the OAR resources would be an advantage.
Tested on a local laptop, will test-deploy on all the currently-supported board types and see what happens. We might still have problems with duplicated udev rules (I think some boards match multiple udev rules and thus multiple /dev/iotlab/ttyON...)