### PR TITLE
open_nodes: use generic STLINK port for ST LRWAN1

### DIFF
--- a/bin/rules.d/st_lrwan1.rules
+++ b/bin/rules.d/st_lrwan1.rules
@@ -1,3 +1,0 @@
-# open nodes TTY
-KERNEL=="ttyACM*",SUBSYSTEM=="tty", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374b", SUBSYSTEMS=="usb", SYMLINK+="iotlab/ttyON_ST_LRWAN1"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374b", MODE="0664", GROUP="dialout"

--- a/bin/rules.d/stlink.rules
+++ b/bin/rules.d/stlink.rules
@@ -1,0 +1,3 @@
+# open nodes TTY
+KERNEL=="ttyACM*",SUBSYSTEM=="tty", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374b", SUBSYSTEMS=="usb", SYMLINK+="iotlab/ttyON_STLINK"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374b", MODE="0664", GROUP="dialout"

--- a/gateway_code/open_nodes/common/__init__.py
+++ b/gateway_code/open_nodes/common/__init__.py
@@ -19,16 +19,4 @@
 # The fact that you are presently reading this means that you have had
 # knowledge of the CeCILL license and that you accept its terms.
 
-""" Open Node STM32 LRWAN1 experiment implementation """
-
-from gateway_code.config import static_path
-from gateway_code.open_nodes.common.node_st_link import NodeStLinkBase
-
-
-class NodeStLrwan1(NodeStLinkBase):
-    """ Open node STM32 LRWAN1 implemention """
-
-    TYPE = 'st_lrwan1'
-    OPENOCD_CFG_FILE = static_path('iot-lab-st-lrwan1.cfg')
-    FW_IDLE = static_path('st_lrwan1_idle.elf')
-    FW_AUTOTEST = static_path('st_lrwan1_autotest.elf')
+""" common code for open nodes """

--- a/gateway_code/open_nodes/common/node_st_link.py
+++ b/gateway_code/open_nodes/common/node_st_link.py
@@ -1,0 +1,130 @@
+# -*- coding:utf-8 -*-
+
+# This file is a part of IoT-LAB gateway_code
+# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Contributor(s) : see AUTHORS file
+#
+# This software is governed by the CeCILL license under French law
+# and abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# http://www.cecill.info.
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+
+""" Open Node based on ST-Link programmer implementation """
+import logging
+
+import serial
+
+from gateway_code.nodes import OpenNodeBase
+from gateway_code import common
+from gateway_code.common import logger_call
+
+from gateway_code.utils.openocd import OpenOCD
+from gateway_code.utils.serial_redirection import SerialRedirection
+
+LOGGER = logging.getLogger('gateway_code')
+
+
+class NodeStLinkBase(OpenNodeBase):
+    # pylint:disable=no-member
+    """ Open node STM32 St-Link based board implementation """
+
+    ELF_TARGET = ('ELFCLASS32', 'EM_ARM')
+    TTY = '/dev/iotlab/ttyON_STLINK'
+    BAUDRATE = 115200
+    OPENOCD_PATH = '/opt/openocd-0.10.0/bin/openocd'
+    DIRTY_SERIAL = True
+
+    AUTOTEST_AVAILABLE = [
+        'echo', 'get_time',  # mandatory
+        'leds_on', 'leds_off'
+    ]
+
+    ALIM = '5V'
+
+    def __init__(self):
+        self.serial_redirection = SerialRedirection(self.TTY, self.BAUDRATE)
+        self.openocd = OpenOCD.from_node(self)
+
+    def clear_serial(self):
+        """Clear serial link by flushing the input buffer."""
+        try:
+            ser = serial.Serial(self.TTY, self.BAUDRATE)
+        except serial.serialutil.SerialException:
+            LOGGER.error("No serial port found")
+            return 1
+        ser.reset_input_buffer()
+        ser.close()
+        return 0
+
+    @logger_call("Node ST_LINK : Setup of st_iotnode node")
+    def setup(self, firmware_path):
+        """ Flash open node, create serial redirection """
+        ret_val = 0
+
+        common.wait_no_tty(self.TTY)
+        ret_val += common.wait_tty(self.TTY, LOGGER)
+        ret_val += self.flash(firmware_path)
+        ret_val += self.serial_redirection.start()
+        return ret_val
+
+    @logger_call("Node ST_LINK : teardown of st_iotnode node")
+    def teardown(self):
+        """ Stop serial redirection and flash idle firmware """
+        ret_val = 0
+        # ON may have been stopped at the end of the experiment.
+        # And then restarted again in cn teardown.
+        # This leads to problem where the TTY disappears and reappears during
+        # the first 2 seconds. So let some time if it wants to disappear first.
+        common.wait_no_tty(self.TTY)
+        ret_val += common.wait_tty(self.TTY, LOGGER)
+        # cleanup debugger before flashing
+        ret_val += self.debug_stop()
+        ret_val += self.serial_redirection.stop()
+        ret_val += self.flash(None)
+        return ret_val
+
+    @logger_call("Node ST_LINK : flash of st_iotnode node")
+    def flash(self, firmware_path=None):
+        """ Flash the given firmware on ST_LINK node
+
+        :param firmware_path: Path to the firmware to be flashed on `node`.
+                              If None, flash 'idle' firmware.
+        """
+        firmware_path = firmware_path or self.FW_IDLE
+        LOGGER.info('Flash firmware on ST_LINK: %s', firmware_path)
+        ret = self.openocd.flash(firmware_path)
+        ret += self.clear_serial()
+        return ret
+
+    @logger_call("Node ST_LINK: reset of st_iotnode node")
+    def reset(self):
+        """ Reset the ST_LINK node using jtag """
+        LOGGER.info('Reset ST_IONODE node')
+        return self.openocd.reset()
+
+    def debug_start(self):
+        """ Start ST_LINK node debugger """
+        LOGGER.info('ST_LINK Node debugger start')
+        return self.openocd.debug_start()
+
+    def debug_stop(self):
+        """ Stop ST_LINK node debugger """
+        LOGGER.info('ST_LINK Node debugger stop')
+        return self.openocd.debug_stop()
+
+    @staticmethod
+    def status():
+        """ Check ST_LINK node status """
+        # Status is called when open node is not powered
+        # So can't check for FTDI
+        return 0

--- a/gateway_code/open_nodes/node_st_lrwan1.py
+++ b/gateway_code/open_nodes/node_st_lrwan1.py
@@ -39,7 +39,7 @@ class NodeStLrwan1(OpenNodeBase):
 
     TYPE = 'st_lrwan1'
     ELF_TARGET = ('ELFCLASS32', 'EM_ARM')
-    TTY = '/dev/iotlab/ttyON_ST_LRWAN1'
+    TTY = '/dev/iotlab/ttyON_STLINK'
     BAUDRATE = 115200
     OPENOCD_CFG_FILE = static_path('iot-lab-st-lrwan1.cfg')
     OPENOCD_PATH = '/opt/openocd-0.10.0/bin/openocd'


### PR DESCRIPTION
This PR generalize the ST LRWAN open node associated udev rules to be st-link. This is because the same udev rules applies to boards with an st-link adapter (all nucleos and other discovery boards).

It's the same problem that was reported for boards having a DAP Link, like the microbit.