### PR TITLE
bin: add daemon script for rtl_tcp

### DIFF
--- a/bin/init_script/rtl-tcp-daemon
+++ b/bin/init_script/rtl-tcp-daemon
@@ -1,0 +1,90 @@
+#!/bin/sh
+
+# This file is a part of IoT-LAB gateway_code
+# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Contributor(s) : see AUTHORS file
+#
+# This software is governed by the CeCILL license under French law
+# and abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# http://www.cecill.info.
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+
+
+# Init script for RTL SDR TCP server
+# http://sdr.osmocom.org/trac/wiki/rtl-sdr
+
+DESC="RTL SDR TCP"
+NAME=rtl_tcp
+RTL_TCP_PORT=50000
+RTL_TCP_FREQ=868000000
+PIDDIR=/var/run/${NAME}
+PIDFILE=$PIDDIR/${NAME}.pid
+LOGDIR=/var/log/${NAME}
+LOGFILE=$LOGDIR/${NAME}.log
+DAEMONUSER=root
+RTL_SDR_CONF_FILE=/var/local/config/rtl_sdr
+
+DAEMON=/usr/bin/${NAME}
+DAEMON_OPTS="-a 0.0.0.0 -p ${RTL_TCP_PORT} -f ${RTL_TCP_FREQ}"
+
+case "$1" in
+  start)
+    if [ -f ${RTL_SDR_CONF_FILE} ]; then
+        echo "Starting $DESC ... "
+        if [ ! -d $PIDDIR ]; then
+            mkdir -p $PIDDIR
+            chown $DAEMONUSER:$DAEMONUSER $PIDDIR
+        fi
+        if [ ! -d $LOGDIR ]; then
+            mkdir -p $LOGDIR
+            chown $DAEMONUSER:$DAEMONUSER $LOGDIR
+        fi
+        start-stop-daemon --start -m --pidfile $PIDFILE -b --chuid $DAEMONUSER:$DAEMONUSER --exec /bin/bash -- -c "exec $DAEMON $DAEMON_OPTS >> $LOGFILE 2>&1"
+    else
+        echo "No RTL SDR dongle"
+    fi
+    ;;
+  stop)
+    if [ -f ${RTL_SDR_CONF_FILE} ]; then
+        echo "Stopping $DESC ... "
+        /sbin/start-stop-daemon --stop --pidfile $PIDFILE
+        # Many daemons don't delete their pidfiles when they exit.
+        rm -f $PIDFILE
+    fi
+    ;;
+  restart)
+    if [ -f ${RTL_SDR_CONF_FILE} ]; then
+        echo -n "Restarting $DESC ... "
+        $0 stop
+        sleep 5
+        $0 start
+    fi
+    ;;
+  status)
+    if [ -f ${RTL_SDR_CONF_FILE} ]; then
+        PID=`/bin/ps -eo 'pid,cmd'| grep $DAEMON | grep -v grep | awk '{sub("^ ", "", $0); print $0}' | cut -d " " -f 1`
+        if [[ -n "$PID" ]]; then
+            echo "$DESC (pid $PID) is running."
+        else
+            echo "$DESC is stopped."
+        fi
+    fi
+    ;;
+  *)
+    echo "Usage: /etc/init.d/rtl-sdr-daemon {start|stop|restart|status}"
+    exit 1
+    ;;
+esac
+
+exit 0
+

--- a/setup.py
+++ b/setup.py
@@ -133,12 +133,14 @@ def post_install(self):
     """System configuration.
 
     * install init.d gateway server daemon script
-    * install init.d gateway camera streamer
+    * install init.d gateway camera streamer daemon script
+    * install init.d gateway rtl sdr daemon script
     * install udev rules files
     * Add www-data user to dialout group
     """
     execute(self, setup_initd_script, args=('gateway-server-daemon',))
     execute(self, setup_initd_script, args=('mjpg-streamer-daemon',))
+    execute(self, setup_initd_script, args=('rtl-tcp-daemon',))
     execute(self, udev_rules)
     execute(self, add_www_data_to_dialout)
 


### PR DESCRIPTION
This PR add a new daemon script for starting a TCP server connected to a potential RTL SDR dongle.

It's similar to the camera daemon in the sense that it checks if the `/var/local/config/rtl_sdr` file is present to start the daemon. Otherwise it does nothing.

The rtl_tcp listen on port 50000 and configure the dongle to listen on 868MHz frequency.