### PR TITLE
Open nodes: add EDBG base class and use it with samr21 and arduino zero

### DIFF
--- a/gateway_code/open_nodes/common/node_edbg.py
+++ b/gateway_code/open_nodes/common/node_edbg.py
@@ -1,0 +1,130 @@
+# -*- coding:utf-8 -*-
+
+# This file is a part of IoT-LAB gateway_code
+# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Contributor(s) : see AUTHORS file
+#
+# This software is governed by the CeCILL license under French law
+# and abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# http://www.cecill.info.
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+
+""" EDBG based Open Node experiment implementation """
+import logging
+
+from gateway_code import common
+from gateway_code.common import logger_call
+from gateway_code.nodes import OpenNodeBase
+
+from gateway_code.utils.openocd import OpenOCD
+from gateway_code.utils.edbg import Edbg
+from gateway_code.utils.serial_redirection import SerialRedirection
+
+LOGGER = logging.getLogger('gateway_code')
+
+
+class NodeEdbgBase(OpenNodeBase):
+    # pylint:disable=no-member
+    """ Open node EDBG implementation """
+
+    ELF_TARGET = ('ELFCLASS32', 'EM_ARM')
+    BAUDRATE = 115200
+
+    AUTOTEST_AVAILABLE = [
+        'echo', 'get_time',  # mandatory
+        'leds_on', 'leds_off'
+    ]
+
+    ALIM = '5V'
+
+    def __init__(self):
+        self.serial_redirection = SerialRedirection(self.TTY, self.BAUDRATE)
+        self.openocd = OpenOCD.from_node(self)
+        self.edbg = Edbg()
+        self._current_fw = None
+        self._in_debug = False
+
+    @logger_call("Node EDBG: Setup of EDBG node")
+    def setup(self, firmware_path):
+        """ Flash open node, create serial redirection """
+        self._in_debug = False
+        ret_val = 0
+
+        common.wait_no_tty(self.TTY)
+        ret_val += common.wait_tty(self.TTY, LOGGER)
+        ret_val += self.flash(firmware_path)
+        ret_val += self.serial_redirection.start()
+        return ret_val
+
+    @logger_call("Node EDBG: teardown of EDBG node")
+    def teardown(self):
+        """ Stop serial redirection and flash idle firmware """
+        self._in_debug = False
+        ret_val = 0
+        # ON may have been stopped at the end of the experiment.
+        # And then restarted again in cn teardown.
+        # This leads to problem where the TTY disappears and reappears during
+        # the first 2 seconds. So let some time if it wants to disappear first.
+        common.wait_no_tty(self.TTY)
+        ret_val += common.wait_tty(self.TTY, LOGGER)
+        # cleanup debugger before flashing
+        ret_val += self.debug_stop()
+        ret_val += self.serial_redirection.stop()
+        ret_val += self.flash(None)
+        return ret_val
+
+    @logger_call("Node EDBG: flash of edbg node")
+    def flash(self, firmware_path=None):
+        """ Flash the given firmware on EDBG node
+
+        :param firmware_path: Path to the firmware to be flashed on `node`.
+                              If None, flash 'idle' firmware.
+        """
+        firmware_path = firmware_path or self.FW_IDLE
+        LOGGER.info('Flash firmware on %s: %s',
+                    self.TYPE.upper(), firmware_path)
+        self._current_fw = firmware_path
+
+        if self._in_debug:
+            return self.openocd.flash(firmware_path)
+
+        return self.edbg.flash(firmware_path)
+
+    @logger_call("Node EDBG: reset of EDBG node")
+    def reset(self):
+        """ Reset the EDBG node using jtag """
+        LOGGER.info('Reset %s node', self.TYPE.upper())
+        return self.openocd.reset()
+
+    def debug_start(self):
+        """ Start EDBG node debugger """
+        LOGGER.info('%s Node debugger start', self.TYPE.upper())
+        self._in_debug = True
+        if self._current_fw is not None:
+            # Reflash current firmware using openocd to avoid misbehavior of
+            # previously flashed firmware (with edbg)
+            self.flash(firmware_path=self._current_fw)
+        return self.openocd.debug_start()
+
+    def debug_stop(self):
+        """ Stop EDBG node debugger """
+        LOGGER.info('%s Node debugger stop', self.TYPE.upper())
+        self._in_debug = False
+        return self.openocd.debug_stop()
+
+    @staticmethod
+    def status():
+        """ Check EDBG node status """
+        # Status is called when open node is not powered
+        # So can't check for FTDI
+        return 0

--- a/gateway_code/open_nodes/common/node_st_link.py
+++ b/gateway_code/open_nodes/common/node_st_link.py
@@ -66,7 +66,7 @@ class NodeStLinkBase(OpenNodeBase):
         ser.close()
         return 0
 
-    @logger_call("Node ST_LINK : Setup of st_iotnode node")
+    @logger_call("Node ST_LINK: Setup of st-link node")
     def setup(self, firmware_path):
         """ Flash open node, create serial redirection """
         ret_val = 0
@@ -77,7 +77,7 @@ class NodeStLinkBase(OpenNodeBase):
         ret_val += self.serial_redirection.start()
         return ret_val
 
-    @logger_call("Node ST_LINK : teardown of st_iotnode node")
+    @logger_call("Node ST_LINK: teardown of st-link node")
     def teardown(self):
         """ Stop serial redirection and flash idle firmware """
         ret_val = 0
@@ -93,7 +93,7 @@ class NodeStLinkBase(OpenNodeBase):
         ret_val += self.flash(None)
         return ret_val
 
-    @logger_call("Node ST_LINK : flash of st_iotnode node")
+    @logger_call("Node ST_LINK: flash of st-link node")
     def flash(self, firmware_path=None):
         """ Flash the given firmware on ST_LINK node
 
@@ -101,25 +101,26 @@ class NodeStLinkBase(OpenNodeBase):
                               If None, flash 'idle' firmware.
         """
         firmware_path = firmware_path or self.FW_IDLE
-        LOGGER.info('Flash firmware on ST_LINK: %s', firmware_path)
+        LOGGER.info('Flash firmware on %s: %s',
+                    self.TYPE.upper(), firmware_path)
         ret = self.openocd.flash(firmware_path)
         ret += self.clear_serial()
         return ret
 
-    @logger_call("Node ST_LINK: reset of st_iotnode node")
+    @logger_call("Node ST_LINK: reset of st-link node")
     def reset(self):
         """ Reset the ST_LINK node using jtag """
-        LOGGER.info('Reset ST_IONODE node')
+        LOGGER.info('Reset %s node', self.TYPE.upper())
         return self.openocd.reset()
 
     def debug_start(self):
         """ Start ST_LINK node debugger """
-        LOGGER.info('ST_LINK Node debugger start')
+        LOGGER.info('%s Node debugger start', self.TYPE.upper())
         return self.openocd.debug_start()
 
     def debug_stop(self):
         """ Stop ST_LINK node debugger """
-        LOGGER.info('ST_LINK Node debugger stop')
+        LOGGER.info('%s Node debugger stop', self.TYPE.upper())
         return self.openocd.debug_stop()
 
     @staticmethod

--- a/gateway_code/open_nodes/node_arduino_zero.py
+++ b/gateway_code/open_nodes/node_arduino_zero.py
@@ -20,117 +20,16 @@
 # knowledge of the CeCILL license and that you accept its terms.
 
 """ Open Node Arduino Zero experiment implementation """
-import logging
 
 from gateway_code.config import static_path
-from gateway_code import common
-from gateway_code.common import logger_call
-
-from gateway_code.nodes import OpenNodeBase
-from gateway_code.utils.openocd import OpenOCD
-from gateway_code.utils.edbg import Edbg
-from gateway_code.utils.serial_redirection import SerialRedirection
-
-LOGGER = logging.getLogger('gateway_code')
+from gateway_code.open_nodes.common.node_edbg import NodeEdbgBase
 
 
-class NodeArduinoZero(OpenNodeBase):
+class NodeArduinoZero(NodeEdbgBase):
     """ Open node Arduino Zero implementation """
 
     TYPE = 'arduino_zero'
-    ELF_TARGET = ('ELFCLASS32', 'EM_ARM')
     TTY = '/dev/iotlab/ttyON_ARDUINO_ZERO'
-    BAUDRATE = 115200
     OPENOCD_CFG_FILE = static_path('iot-lab-arduino-zero.cfg')
     FW_IDLE = static_path('arduino_zero_idle.elf')
     FW_AUTOTEST = static_path('arduino_zero_autotest.elf')
-
-    AUTOTEST_AVAILABLE = [
-        'echo', 'get_time',  # mandatory
-        'leds_on', 'leds_off'
-    ]
-
-    ALIM = '5V'
-
-    def __init__(self):
-        self.serial_redirection = SerialRedirection(self.TTY, self.BAUDRATE)
-        self.openocd = OpenOCD.from_node(self)
-        self.edbg = Edbg()
-        self._current_fw = None
-        self._in_debug = False
-
-    @logger_call("Node Arduino Zero : Setup of arduino zero node")
-    def setup(self, firmware_path):
-        """ Flash open node, create serial redirection """
-        self._in_debug = False
-
-        ret_val = 0
-
-        common.wait_no_tty(self.TTY)
-        ret_val += common.wait_tty(self.TTY, LOGGER)
-        ret_val += self.flash(firmware_path)
-        ret_val += self.serial_redirection.start()
-        return ret_val
-
-    @logger_call("Node Arduino Zero : teardown of arduino zero node")
-    def teardown(self):
-        """ Stop serial redirection and flash idle firmware """
-        self._in_debug = False
-
-        ret_val = 0
-        # ON may have been stopped at the end of the experiment.
-        # And then restarted again in cn teardown.
-        # This leads to problem where the TTY disappears and reappears during
-        # the first 2 seconds. So let some time if it wants to disappear first.
-        common.wait_no_tty(self.TTY)
-        ret_val += common.wait_tty(self.TTY, LOGGER)
-        # cleanup debugger before flashing
-        ret_val += self.debug_stop()
-        ret_val += self.serial_redirection.stop()
-        ret_val += self.flash(None)
-        return ret_val
-
-    @logger_call("Node Arduino Zero : flash of arduino zero node")
-    def flash(self, firmware_path=None):
-        """ Flash the given firmware on Arduino Zero node
-
-        :param firmware_path: Path to the firmware to be flashed on `node`.
-                              If None, flash 'idle' firmware.
-        """
-        firmware_path = firmware_path or self.FW_IDLE
-        LOGGER.info('Flash firmware on Arduino Zero: %s', firmware_path)
-        self._current_fw = firmware_path
-
-        if self._in_debug:
-            return self.openocd.flash(firmware_path)
-
-        return self.edbg.flash(firmware_path)
-
-    @logger_call("Node Arduino Zero : reset of arduino zero node")
-    def reset(self):
-        """ Reset the Arduino Zero node using jtag """
-        LOGGER.info('Reset Arduino Zero node')
-        return self.openocd.reset()
-
-    def debug_start(self):
-        """ Start Arduino Zero node debugger """
-        LOGGER.info('Arduino Zero Node debugger start')
-        self._in_debug = True
-        if self._current_fw is not None:
-            # Reflash current firmware using openocd to avoid misbehavior of
-            # previously flashed firmware (with edbg)
-            self.flash(firmware_path=self._current_fw)
-        return self.openocd.debug_start()
-
-    def debug_stop(self):
-        """ Stop Arduino Zero node debugger """
-        LOGGER.info('Arduino Zero Node debugger stop')
-        self._in_debug = False
-        return self.openocd.debug_stop()
-
-    @staticmethod
-    def status():
-        """ Check Arduino Zero node status """
-        # Status is called when open node is not powered
-        # So can't check for FTDI
-        return 0

--- a/gateway_code/open_nodes/node_samr21.py
+++ b/gateway_code/open_nodes/node_samr21.py
@@ -20,115 +20,16 @@
 # knowledge of the CeCILL license and that you accept its terms.
 
 """ Open Node SAMR21 experiment implementation """
-import logging
 
 from gateway_code.config import static_path
-from gateway_code import common
-from gateway_code.common import logger_call
-from gateway_code.nodes import OpenNodeBase
-
-from gateway_code.utils.openocd import OpenOCD
-from gateway_code.utils.edbg import Edbg
-from gateway_code.utils.serial_redirection import SerialRedirection
-
-LOGGER = logging.getLogger('gateway_code')
+from gateway_code.open_nodes.common.node_edbg import NodeEdbgBase
 
 
-class NodeSamr21(OpenNodeBase):
+class NodeSamr21(NodeEdbgBase):
     """ Open node SAMR21 implemention """
 
     TYPE = 'samr21'
-    ELF_TARGET = ('ELFCLASS32', 'EM_ARM')
     TTY = '/dev/iotlab/ttyON_SAMR21'
-    BAUDRATE = 115200
     OPENOCD_CFG_FILE = static_path('iot-lab-samr21.cfg')
     FW_IDLE = static_path('samr21_idle.elf')
     FW_AUTOTEST = static_path('samr21_autotest.elf')
-
-    AUTOTEST_AVAILABLE = [
-        'echo', 'get_time',  # mandatory
-        'leds_on', 'leds_off'
-    ]
-
-    ALIM = '5V'
-
-    def __init__(self):
-        self.serial_redirection = SerialRedirection(self.TTY, self.BAUDRATE)
-        self.openocd = OpenOCD.from_node(self)
-        self.edbg = Edbg()
-        self._current_fw = None
-        self._in_debug = False
-
-    @logger_call("Node SAMR21 : Setup of samr21 node")
-    def setup(self, firmware_path):
-        """ Flash open node, create serial redirection """
-        self._in_debug = False
-        ret_val = 0
-
-        common.wait_no_tty(self.TTY)
-        ret_val += common.wait_tty(self.TTY, LOGGER)
-        ret_val += self.flash(firmware_path)
-        ret_val += self.serial_redirection.start()
-        return ret_val
-
-    @logger_call("Node SAMR21 : teardown of samr21 node")
-    def teardown(self):
-        """ Stop serial redirection and flash idle firmware """
-        self._in_debug = False
-        ret_val = 0
-        # ON may have been stopped at the end of the experiment.
-        # And then restarted again in cn teardown.
-        # This leads to problem where the TTY disappears and reappears during
-        # the first 2 seconds. So let some time if it wants to disappear first.
-        common.wait_no_tty(self.TTY)
-        ret_val += common.wait_tty(self.TTY, LOGGER)
-        # cleanup debugger before flashing
-        ret_val += self.debug_stop()
-        ret_val += self.serial_redirection.stop()
-        ret_val += self.flash(None)
-        return ret_val
-
-    @logger_call("Node SAMR21 : flash of sam21 node")
-    def flash(self, firmware_path=None):
-        """ Flash the given firmware on SAMR21 node
-
-        :param firmware_path: Path to the firmware to be flashed on `node`.
-                              If None, flash 'idle' firmware.
-        """
-        firmware_path = firmware_path or self.FW_IDLE
-        LOGGER.info('Flash firmware on SAMR21: %s', firmware_path)
-        self._current_fw = firmware_path
-
-        if self._in_debug:
-            return self.openocd.flash(firmware_path)
-
-        return self.edbg.flash(firmware_path)
-
-    @logger_call("Node SAMR21 : reset of samr21 node")
-    def reset(self):
-        """ Reset the SAMR21 node using jtag """
-        LOGGER.info('Reset SAMR21 node')
-        return self.openocd.reset()
-
-    def debug_start(self):
-        """ Start SAMR21 node debugger """
-        LOGGER.info('SAMR21 Node debugger start')
-        self._in_debug = True
-        if self._current_fw is not None:
-            # Reflash current firmware using openocd to avoid misbehavior of
-            # previously flashed firmware (with edbg)
-            self.flash(firmware_path=self._current_fw)
-        return self.openocd.debug_start()
-
-    def debug_stop(self):
-        """ Stop SAMR21 node debugger """
-        LOGGER.info('SAMR21 Node debugger stop')
-        self._in_debug = False
-        return self.openocd.debug_stop()
-
-    @staticmethod
-    def status():
-        """ Check SAMR21 node status """
-        # Status is called when open node is not powered
-        # So can't check for FTDI
-        return 0


### PR DESCRIPTION
This PR factorize the open nodes implmentation of the arduino-zero and samr21 boards.

It also does a small cleanup in the st-link base class.

Integration tests have passed for samr21 and arduino-zero.