### PR TITLE
control_nodes: add RPI3 control node

### DIFF
--- a/gateway_code/control_nodes/cn_rpi3/__init__.py
+++ b/gateway_code/control_nodes/cn_rpi3/__init__.py
@@ -1,0 +1,133 @@
+# -*- coding:utf-8 -*-
+
+# This file is a part of IoT-LAB gateway_code
+# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Contributor(s) : see AUTHORS file
+#
+# This software is governed by the CeCILL license under French law
+# and abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# http://www.cecill.info.
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+
+"""Control Node experiment implementation RPI3 ControlNode."""
+
+import logging
+import shlex
+
+from gateway_code.common import logger_call
+from gateway_code.nodes import ControlNodeBase
+from gateway_code.utils import subprocess_timeout
+
+LOGGER = logging.getLogger('gateway_code')
+
+# This command controls all 4 USB ports of the RPI3. The expected paramter is
+# either 0 (poweroff) or 1 (poweron)
+HUB_CTRL_CMD = "sudo hub-ctrl -h 0 -P 2 -p {}"
+
+
+def _call_cmd(command_str):
+    """ Run the given command_str."""
+
+    kwargs = {'args': shlex.split(command_str)}
+    try:
+        return subprocess_timeout.call(**kwargs)
+    except subprocess_timeout.TimeoutExpired as exc:
+        LOGGER.error("HUB_CTRL '%s' timeout: %s", command_str, exc)
+        return 1
+
+
+class ControlNodeRpi3(ControlNodeBase):
+    """ No Control Node """
+    TYPE = 'rpi3'
+    FEATURES = ['open_node_power']
+
+    def __init__(self, node_id, default_profile):
+        self.node_id = node_id
+        self.default_profile = default_profile
+        self.profile = self.default_profile
+        self.open_node_state = 'stop'
+
+    @logger_call("Control node: Start")
+    def start(self, exp_id, exp_files=None):  # pylint:disable=unused-argument
+        """ Start ControlNode serial interface """
+        ret_val = 0
+        ret_val += self.open_start('dc')
+        return ret_val
+
+    @logger_call("Control node: Stop")
+    def stop(self):
+        """ Start ControlNode """
+        ret_val = 0
+        ret_val += self.open_stop('dc')
+        return ret_val
+
+    @staticmethod
+    @logger_call("Control node: Setup")
+    def setup():
+        """Setup control node."""
+        return 0
+
+    @logger_call("Control node: start power of open node")
+    def open_start(self, power=None):  # pylint:disable=unused-argument
+        """ Start open node with 'power' source """
+        ret = _call_cmd(HUB_CTRL_CMD.format(1))
+        if ret == 0:
+            self.open_node_state = 'start'
+        return ret
+
+    @logger_call("Control node: stop power of open node")
+    def open_stop(self, power=None):  # pylint:disable=unused-argument
+        """ Stop open node with 'power' source """
+        ret = _call_cmd(HUB_CTRL_CMD.format(0))
+        if ret == 0:
+            self.open_node_state = 'stop'
+        return ret
+
+    @logger_call("Control node: Flash")
+    def flash(self, firmware_path=None):  # pylint:disable=unused-argument
+        """Flash control node"""
+        return 0
+
+    @logger_call("Control node: Start experiment")
+    def start_experiment(self, profile):
+        """ Configure the experiment """
+        ret_val = 0
+        ret_val += self.configure_profile(profile)
+        return ret_val
+
+    @logger_call("Control node: Stop the experiment")
+    def stop_experiment(self):
+        """Cleanup the control node configuration."""
+        ret_val = 0
+        ret_val += self.configure_profile(None)
+        ret_val += self.open_start('dc')
+        return ret_val
+
+    def autotest_setup(self, measures_handler):
+        """Setup for autotests."""
+        return 0
+
+    def autotest_teardown(self, stop_on):
+        """Teardown autotests."""
+        return 0
+
+    @logger_call("Control node: profile configuration")
+    def configure_profile(self, profile=None):
+        """ Configure the given profile on the control node """
+        LOGGER.info('Configure profile on Control Node')
+        self.profile = profile or self.default_profile
+        return 0
+
+    def status(self):
+        """ Check Control node status """
+        return 0

--- a/gateway_code/control_nodes/cn_rpi3/tests/__init__.py
+++ b/gateway_code/control_nodes/cn_rpi3/tests/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding:utf-8 -*-
+
+# This file is a part of IoT-LAB gateway_code
+# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Contributor(s) : see AUTHORS file
+#
+# This software is governed by the CeCILL license under French law
+# and abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# http://www.cecill.info.
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+
+""" gateway_code.control_node (RPI3) unit tests files """

--- a/gateway_code/control_nodes/cn_rpi3/tests/cn_rpi3_test.py
+++ b/gateway_code/control_nodes/cn_rpi3/tests/cn_rpi3_test.py
@@ -1,0 +1,104 @@
+# -*- coding:utf-8 -*-
+
+# This file is a part of IoT-LAB gateway_code
+# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Contributor(s) : see AUTHORS file
+#
+# This software is governed by the CeCILL license under French law
+# and abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# http://www.cecill.info.
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+
+""" gateway_code.control_node (RPI3) unit tests files """
+
+import mock
+
+from gateway_code.control_nodes.cn_rpi3 import ControlNodeRpi3
+from gateway_code.utils import subprocess_timeout
+
+
+def test_rpi3_control_node_basic():
+    """Test basic empty features of RPI3 control node."""
+
+    # Setup doesn't nothing but is required. It always returns 0
+    assert ControlNodeRpi3.setup() == 0
+
+    # Flash and status does nothing
+    cn_rpi3 = ControlNodeRpi3('test', None)
+    assert cn_rpi3.flash() == 0
+    assert cn_rpi3.status() == 0
+    assert cn_rpi3.autotest_setup(None) == 0
+    assert cn_rpi3.autotest_teardown(None) == 0
+
+
+@mock.patch('gateway_code.utils.subprocess_timeout.call')
+def test_rpi3_control_node_start(call):
+    """Test open node start calls the right command."""
+    call.return_value = 0
+
+    cn_rpi3 = ControlNodeRpi3('test', None)
+    cn_rpi3.start('test')
+
+    call.assert_called_with(
+        args=['sudo', 'hub-ctrl', '-h', '0', '-P', '2', '-p', '1'])
+
+    assert cn_rpi3.open_node_state == 'start'
+
+
+@mock.patch('gateway_code.utils.subprocess_timeout.call')
+def test_rpi3_control_node_stop(call):
+    """Test open node start calls the right command."""
+    call.return_value = 0
+
+    cn_rpi3 = ControlNodeRpi3('test', None)
+    cn_rpi3.stop()
+
+    call.assert_called_with(
+        args=['sudo', 'hub-ctrl', '-h', '0', '-P', '2', '-p', '0'])
+
+    assert cn_rpi3.open_node_state == 'stop'
+
+
+@mock.patch('gateway_code.utils.subprocess_timeout.call')
+def test_rpi3_control_node_timeout(call):
+    """Test open node start/stop with timeout."""
+    call.side_effect = subprocess_timeout.TimeoutExpired(mock.Mock("test"),
+                                                         'timeout')
+
+    cn_rpi3 = ControlNodeRpi3('test', None)
+    ret = cn_rpi3.start('test')
+
+    assert cn_rpi3.open_node_state == 'stop'
+    assert ret == 1
+
+    ret = cn_rpi3.stop()
+
+    assert cn_rpi3.open_node_state == 'stop'
+    assert ret == 1
+
+
+@mock.patch('gateway_code.utils.subprocess_timeout.call')
+def test_rpi3_configure_profile(call):
+    """Test open node profile confguration with start/stop experiment."""
+    call.return_value = 0
+    cn_rpi3 = ControlNodeRpi3('test', None)
+
+    ret = cn_rpi3.start_experiment("test")
+
+    assert ret == 0
+    assert cn_rpi3.profile == "test"
+
+    ret = cn_rpi3.stop_experiment()
+
+    assert ret == 0
+    assert cn_rpi3.profile is None


### PR DESCRIPTION
For the moment it only provides the open-node-power feature of a plugged open node.

Unit tests have been added.

Work that remains:
- being able to run the tool with user www-data because for the moment I could only make it work as root on a gateway
- test it with integration test (requires update of resource file)
- test it with nrf52dk-2 in devsaclay and see if it fixes the serial link access problem for this open node