### PR TITLE
tests: improve code coverage with unit tests

### DIFF
--- a/gateway_code/control_nodes/cn_no/tests/__init__.py
+++ b/gateway_code/control_nodes/cn_no/tests/__init__.py
@@ -1,0 +1,18 @@
+# This file is a part of IoT-LAB gateway_code
+# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Contributor(s) : see AUTHORS file
+#
+# This software is governed by the CeCILL license under French law
+# and abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# http://www.cecill.info.
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.

--- a/gateway_code/control_nodes/cn_no/tests/cn_no_test.py
+++ b/gateway_code/control_nodes/cn_no/tests/cn_no_test.py
@@ -1,0 +1,55 @@
+# -*- coding:utf-8 -*-
+
+# This file is a part of IoT-LAB gateway_code
+# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Contributor(s) : see AUTHORS file
+#
+# This software is governed by the CeCILL license under French law
+# and abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# http://www.cecill.info.
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+
+""" gateway_code.control_node (No) unit tests files """
+
+import mock
+
+from gateway_code.control_nodes.cn_no import ControlNodeNo
+
+
+def test_control_node_no_basic():
+    """Test basic empty features when there's no control node."""
+
+    # Setup always returns 0
+    assert ControlNodeNo.setup() == 0
+
+    # Flash and status does nothing
+    cn_no = ControlNodeNo('test', None)
+    assert cn_no.start('test') == 0
+    assert cn_no.stop() == 0
+    assert cn_no.flash() == 0
+    assert cn_no.status() == 0
+    assert cn_no.autotest_setup(None) == 0
+    assert cn_no.autotest_teardown(None) == 0
+    assert cn_no.start_experiment("test") == 0
+    assert cn_no.stop_experiment() == 0
+
+
+@mock.patch("gateway_code.control_nodes.cn_no.ControlNodeNo.configure_profile")
+def test_start_stop_experiment(config):
+    """Test starting and stoping experiment."""
+    config.return_value = 0
+    cn_no = ControlNodeNo('test', None)
+    assert cn_no.start_experiment("test") == 0
+    config.assert_called_with("test")
+    assert cn_no.stop_experiment() == 0
+    config.assert_called_with(None)

--- a/gateway_code/nodes.py
+++ b/gateway_code/nodes.py
@@ -114,6 +114,8 @@ def import_all_nodes(pkg_dir):
     """Looks into the given relative path for modules and imports them"""
     pkg_dir = os.path.join(os.path.dirname(__file__), pkg_dir)
     for (module_loader, name, _) in pkgutil.iter_modules([pkg_dir]):
+        if name in ['tests', 'common']:
+            continue
         module_loader.find_module(name).load_module(name)
 
 

--- a/gateway_code/open_nodes/common/node_jlink.py
+++ b/gateway_code/open_nodes/common/node_jlink.py
@@ -20,96 +20,13 @@
 # knowledge of the CeCILL license and that you accept its terms.
 
 """ Open Node JLink based experiment implementation """
-import logging
 
-from gateway_code import common
-from gateway_code.common import logger_call
-from gateway_code.nodes import OpenNodeBase
-
-from gateway_code.utils.openocd import OpenOCD
-from gateway_code.utils.serial_redirection import SerialRedirection
-
-LOGGER = logging.getLogger('gateway_code')
+from gateway_code.open_nodes.common.node_openocd import NodeOpenOCDBase
 
 
-class NodeJLinkBase(OpenNodeBase):
+class NodeJLinkBase(NodeOpenOCDBase):
     # pylint:disable=no-member
     """ Open node JLink implemention """
 
-    ELF_TARGET = ('ELFCLASS32', 'EM_ARM')
     TTY = '/dev/iotlab/ttyON_JLINK'
     BAUDRATE = 115200
-    OPENOCD_PATH = '/opt/openocd-0.10.0/bin/openocd'
-
-    AUTOTEST_AVAILABLE = [
-        'echo', 'get_time',  # mandatory
-        'leds_on', 'leds_off'
-    ]
-
-    ALIM = '5V'
-
-    def __init__(self):
-        self.serial_redirection = SerialRedirection(self.TTY, self.BAUDRATE)
-        self.openocd = OpenOCD.from_node(self)
-
-    @logger_call("Node JLink: Setup of jlink node")
-    def setup(self, firmware_path):
-        """ Flash open node, create serial redirection """
-        ret_val = 0
-
-        common.wait_no_tty(self.TTY)
-        ret_val += common.wait_tty(self.TTY, LOGGER)
-        ret_val += self.flash(firmware_path)
-        ret_val += self.serial_redirection.start()
-        return ret_val
-
-    @logger_call("Node JLink: teardown of jlink node")
-    def teardown(self):
-        """ Stop serial redirection and flash idle firmware """
-        ret_val = 0
-        # ON may have been stopped at the end of the experiment.
-        # And then restarted again in cn teardown.
-        # This leads to problem where the TTY disappears and reappears during
-        # the first 2 seconds. So let some time if it wants to disappear first.
-        common.wait_no_tty(self.TTY)
-        ret_val += common.wait_tty(self.TTY, LOGGER)
-        # cleanup debugger before flashing
-        ret_val += self.debug_stop()
-        ret_val += self.serial_redirection.stop()
-        ret_val += self.flash(None)
-        return ret_val
-
-    @logger_call("Node JLink: flash of jlink node")
-    def flash(self, firmware_path=None):
-        """ Flash the given firmware on jlink node
-
-        :param firmware_path: Path to the firmware to be flashed on `node`.
-                              If None, flash 'idle' firmware.
-        """
-        firmware_path = firmware_path or self.FW_IDLE
-        LOGGER.info('Flash firmware on JLink: %s', firmware_path)
-        ret = self.openocd.flash(firmware_path)
-        return ret
-
-    @logger_call("Node JLink: reset of jlink node")
-    def reset(self):
-        """ Reset the jlink node using jtag """
-        LOGGER.info('Reset jlink node')
-        return self.openocd.reset()
-
-    def debug_start(self):
-        """ Start jlink node debugger """
-        LOGGER.info('jlink node debugger start')
-        return self.openocd.debug_start()
-
-    def debug_stop(self):
-        """ Stop jlink node debugger """
-        LOGGER.info('jlink node debugger stop')
-        return self.openocd.debug_stop()
-
-    @staticmethod
-    def status():
-        """ Check jlink node status """
-        # Status is called when open node is not powered
-        # So can't check for FTDI
-        return 0

--- a/gateway_code/open_nodes/common/node_openocd.py
+++ b/gateway_code/open_nodes/common/node_openocd.py
@@ -1,0 +1,126 @@
+# -*- coding:utf-8 -*-
+
+# This file is a part of IoT-LAB gateway_code
+# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Contributor(s) : see AUTHORS file
+#
+# This software is governed by the CeCILL license under French law
+# and abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# http://www.cecill.info.
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+
+""" Open Node using OpenOCD as programmer/debugger """
+import logging
+import serial
+
+from gateway_code import common
+from gateway_code.common import logger_call
+from gateway_code.nodes import OpenNodeBase
+
+from gateway_code.utils.openocd import OpenOCD
+from gateway_code.utils.serial_redirection import SerialRedirection
+
+LOGGER = logging.getLogger('gateway_code')
+
+
+class NodeOpenOCDBase(OpenNodeBase):
+    # pylint:disable=no-member
+    """ Open node OpenOCD implemention """
+
+    ELF_TARGET = ('ELFCLASS32', 'EM_ARM')
+    OPENOCD_PATH = '/opt/openocd-0.10.0/bin/openocd'
+
+    AUTOTEST_AVAILABLE = [
+        'echo', 'get_time',  # mandatory
+        'leds_on', 'leds_off'
+    ]
+
+    ALIM = '5V'
+
+    def __init__(self):
+        self.serial_redirection = SerialRedirection(self.TTY, self.BAUDRATE)
+        self.openocd = OpenOCD.from_node(self)
+
+    def clear_serial(self):
+        """Clear serial link by flushing the input buffer."""
+        try:
+            ser = serial.Serial(self.TTY, self.BAUDRATE)
+        except serial.serialutil.SerialException:
+            LOGGER.error("No serial port found")
+            return 1
+        ser.reset_input_buffer()
+        ser.close()
+        return 0
+
+    @logger_call("Node OpenOCD: Setup of openocd node")
+    def setup(self, firmware_path):
+        """ Flash open node, create serial redirection """
+        ret_val = 0
+
+        common.wait_no_tty(self.TTY)
+        ret_val += common.wait_tty(self.TTY, LOGGER)
+        ret_val += self.flash(firmware_path)
+        ret_val += self.serial_redirection.start()
+        return ret_val
+
+    @logger_call("Node OpenOCD: teardown of openocd node")
+    def teardown(self):
+        """ Stop serial redirection and flash idle firmware """
+        ret_val = 0
+        # ON may have been stopped at the end of the experiment.
+        # And then restarted again in cn teardown.
+        # This leads to problem where the TTY disappears and reappears during
+        # the first 2 seconds. So let some time if it wants to disappear first.
+        common.wait_no_tty(self.TTY)
+        ret_val += common.wait_tty(self.TTY, LOGGER)
+        # cleanup debugger before flashing
+        ret_val += self.debug_stop()
+        ret_val += self.serial_redirection.stop()
+        ret_val += self.flash(None)
+        return ret_val
+
+    @logger_call("Node OpenOCD: flash of openocd node")
+    def flash(self, firmware_path=None):
+        """ Flash the given firmware on openocd node
+
+        :param firmware_path: Path to the firmware to be flashed on `node`.
+                              If None, flash 'idle' firmware.
+        """
+        firmware_path = firmware_path or self.FW_IDLE
+        LOGGER.info('Flash firmware on OpenOCD: %s', firmware_path)
+        ret = self.openocd.flash(firmware_path)
+        if hasattr(self, 'DIRTY_SERIAL') and self.DIRTY_SERIAL:
+            ret += self.clear_serial()
+        return ret
+
+    @logger_call("Node OpenOCD: reset of openocd node")
+    def reset(self):
+        """ Reset the openocd node using jtag """
+        LOGGER.info('Reset openocd node')
+        return self.openocd.reset()
+
+    def debug_start(self):
+        """ Start openocd node debugger """
+        LOGGER.info('openocd node debugger start')
+        return self.openocd.debug_start()
+
+    def debug_stop(self):
+        """ Stop openocd node debugger """
+        LOGGER.info('openocd node debugger stop')
+        return self.openocd.debug_stop()
+
+    @staticmethod
+    def status():
+        """ Check openocd node status """
+        # Status is called when open node is not powered
+        return 0

--- a/gateway_code/open_nodes/common/node_st_link.py
+++ b/gateway_code/open_nodes/common/node_st_link.py
@@ -20,21 +20,11 @@
 # knowledge of the CeCILL license and that you accept its terms.
 
 """ Open Node based on ST-Link programmer implementation """
-import logging
 
-import serial
-
-from gateway_code.nodes import OpenNodeBase
-from gateway_code import common
-from gateway_code.common import logger_call
-
-from gateway_code.utils.openocd import OpenOCD
-from gateway_code.utils.serial_redirection import SerialRedirection
-
-LOGGER = logging.getLogger('gateway_code')
+from gateway_code.open_nodes.common.node_openocd import NodeOpenOCDBase
 
 
-class NodeStLinkBase(OpenNodeBase):
+class NodeStLinkBase(NodeOpenOCDBase):
     # pylint:disable=no-member
     """ Open node STM32 St-Link based board implementation """
 
@@ -43,89 +33,3 @@ class NodeStLinkBase(OpenNodeBase):
     BAUDRATE = 115200
     OPENOCD_PATH = '/opt/openocd-0.10.0/bin/openocd'
     DIRTY_SERIAL = True
-
-    AUTOTEST_AVAILABLE = [
-        'echo', 'get_time',  # mandatory
-        'leds_on', 'leds_off'
-    ]
-
-    ALIM = '5V'
-
-    def __init__(self):
-        self.serial_redirection = SerialRedirection(self.TTY, self.BAUDRATE)
-        self.openocd = OpenOCD.from_node(self)
-
-    def clear_serial(self):
-        """Clear serial link by flushing the input buffer."""
-        try:
-            ser = serial.Serial(self.TTY, self.BAUDRATE)
-        except serial.serialutil.SerialException:
-            LOGGER.error("No serial port found")
-            return 1
-        ser.reset_input_buffer()
-        ser.close()
-        return 0
-
-    @logger_call("Node ST_LINK: Setup of st-link node")
-    def setup(self, firmware_path):
-        """ Flash open node, create serial redirection """
-        ret_val = 0
-
-        common.wait_no_tty(self.TTY)
-        ret_val += common.wait_tty(self.TTY, LOGGER)
-        ret_val += self.flash(firmware_path)
-        ret_val += self.serial_redirection.start()
-        return ret_val
-
-    @logger_call("Node ST_LINK: teardown of st-link node")
-    def teardown(self):
-        """ Stop serial redirection and flash idle firmware """
-        ret_val = 0
-        # ON may have been stopped at the end of the experiment.
-        # And then restarted again in cn teardown.
-        # This leads to problem where the TTY disappears and reappears during
-        # the first 2 seconds. So let some time if it wants to disappear first.
-        common.wait_no_tty(self.TTY)
-        ret_val += common.wait_tty(self.TTY, LOGGER)
-        # cleanup debugger before flashing
-        ret_val += self.debug_stop()
-        ret_val += self.serial_redirection.stop()
-        ret_val += self.flash(None)
-        return ret_val
-
-    @logger_call("Node ST_LINK: flash of st-link node")
-    def flash(self, firmware_path=None):
-        """ Flash the given firmware on ST_LINK node
-
-        :param firmware_path: Path to the firmware to be flashed on `node`.
-                              If None, flash 'idle' firmware.
-        """
-        firmware_path = firmware_path or self.FW_IDLE
-        LOGGER.info('Flash firmware on %s: %s',
-                    self.TYPE.upper(), firmware_path)
-        ret = self.openocd.flash(firmware_path)
-        ret += self.clear_serial()
-        return ret
-
-    @logger_call("Node ST_LINK: reset of st-link node")
-    def reset(self):
-        """ Reset the ST_LINK node using jtag """
-        LOGGER.info('Reset %s node', self.TYPE.upper())
-        return self.openocd.reset()
-
-    def debug_start(self):
-        """ Start ST_LINK node debugger """
-        LOGGER.info('%s Node debugger start', self.TYPE.upper())
-        return self.openocd.debug_start()
-
-    def debug_stop(self):
-        """ Stop ST_LINK node debugger """
-        LOGGER.info('%s Node debugger stop', self.TYPE.upper())
-        return self.openocd.debug_stop()
-
-    @staticmethod
-    def status():
-        """ Check ST_LINK node status """
-        # Status is called when open node is not powered
-        # So can't check for FTDI
-        return 0

--- a/gateway_code/open_nodes/common/tests/__init__.py
+++ b/gateway_code/open_nodes/common/tests/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding:utf-8 -*-
+
+# This file is a part of IoT-LAB gateway_code
+# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Contributor(s) : see AUTHORS file
+#
+# This software is governed by the CeCILL license under French law
+# and abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# http://www.cecill.info.
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+
+""" gateway_code.open_nodes.common unit tests files """

--- a/gateway_code/open_nodes/common/tests/node_edbg_test.py
+++ b/gateway_code/open_nodes/common/tests/node_edbg_test.py
@@ -24,6 +24,7 @@
 import unittest
 from mock import patch, Mock
 
+from gateway_code.nodes import OpenNodeBase
 from gateway_code.open_nodes.common.node_edbg import NodeEdbgBase
 from gateway_code.open_nodes.node_arduino_zero import NodeArduinoZero
 
@@ -61,6 +62,11 @@ class TestNodeEdbgBase(unittest.TestCase):
 
     def tearDown(self):
         patch.stopall()
+
+    @classmethod
+    def tearDownClass(cls):
+        # Explicitly clear OpenNodeBase registry at the end of all tests.
+        del OpenNodeBase.__registry__[NodeEdbgTest.TYPE]
 
     def test_edbg_node_basic(self):
         """Test basic functions of an edbg based node."""

--- a/gateway_code/open_nodes/common/tests/node_edbg_test.py
+++ b/gateway_code/open_nodes/common/tests/node_edbg_test.py
@@ -1,0 +1,133 @@
+# -*- coding:utf-8 -*-
+
+# This file is a part of IoT-LAB gateway_code
+# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Contributor(s) : see AUTHORS file
+#
+# This software is governed by the CeCILL license under French law
+# and abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# http://www.cecill.info.
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+
+""" gateway_code.open_nodes.common.node_edbg unit tests files """
+
+import unittest
+from mock import patch, Mock
+
+from gateway_code.open_nodes.common.node_edbg import NodeEdbgBase
+from gateway_code.open_nodes.node_arduino_zero import NodeArduinoZero
+
+
+class NodeEdbgTest(NodeEdbgBase):
+    """A test node derived from NodeOpenOCDBase."""
+    TYPE = 'edbgnode_test'
+    TTY = '/dev/iotlab/ttyTestEdbgNode'
+    BAUDRATE = 115200
+    OPENOCD_CFG_FILE = NodeArduinoZero.OPENOCD_CFG_FILE
+    FW_IDLE = NodeArduinoZero.FW_IDLE
+    FW_AUTOTEST = NodeArduinoZero.FW_AUTOTEST
+
+
+class TestNodeEdbgBase(unittest.TestCase):
+    """Unittest class for OpenOCD based open nodes."""
+
+    def setUp(self):
+        self.node = NodeEdbgTest()
+        self.fw_path = '/path/to/firmware'
+        openocd_class = patch('gateway_code.utils.openocd.OpenOCD').start()
+        self.node.openocd = openocd_class.return_value
+        self.node.openocd.flash.return_value = 0
+        self.node.openocd.reset.return_value = 0
+        self.node.openocd.flash.return_value = 0
+        self.node.openocd.debug_start.return_value = 0
+        self.node.openocd.debug_stop.return_value = 0
+        edbg_class = patch('gateway_code.utils.edbg.Edbg').start()
+        self.node.edbg = edbg_class.return_value
+        self.node.edbg.flash.return_value = 0
+        self.node.serial_redirection.start = Mock()
+        self.node.serial_redirection.start.return_value = 0
+        self.node.serial_redirection.stop = Mock()
+        self.node.serial_redirection.stop.return_value = 0
+
+    def tearDown(self):
+        patch.stopall()
+
+    def test_edbg_node_basic(self):
+        """Test basic functions of an edbg based node."""
+        # Reset the node
+        assert not self.node.reset()
+        self.node.openocd.reset.assert_called_once()
+
+        # Node status always returns 0
+        assert NodeEdbgTest.status() == 0
+
+        # debug start
+        assert self.node.debug_start() == 0
+
+        # debug stop
+        assert self.node.debug_stop() == 0
+
+    @patch('gateway_code.common.wait_tty')
+    @patch('gateway_code.common.wait_no_tty')
+    def test_edbg_node_flash(self, no_tty, tty):
+        """Test flash function of an edbg based node."""
+        no_tty.return_value = 0
+        tty.return_value = 0
+        # Setup the node
+        assert self.node.setup(self.fw_path) == 0
+        assert self.node.edbg.flash.call_count == 1
+        self.node.edbg.flash.assert_called_with(self.fw_path)
+
+        # Teardown the node
+        assert self.node.teardown() == 0
+        self.node.edbg.flash.assert_called_with(self.node.FW_IDLE)
+
+        # Flash a firmware
+        assert self.node.flash(self.fw_path) == 0
+        self.node.edbg.flash.assert_called_with(self.fw_path)
+
+        assert self.node.flash() == 0
+        self.node.edbg.flash.assert_called_with(self.node.FW_IDLE)
+
+    @patch('gateway_code.common.wait_tty')
+    @patch('gateway_code.common.wait_no_tty')
+    def test_edbg_node_flash_with_debug(self, no_tty, tty):
+        # pylint:disable=protected-access
+        """Test flash function of an edbg based node while in debug session."""
+        no_tty.return_value = 0
+        tty.return_value = 0
+        # Setup the node
+        assert self.node.debug_start() == 0
+        assert self.node.edbg.flash.call_count == 0
+        assert self.node.openocd.flash.call_count == 0  # No current firmware
+        assert self.node._in_debug
+
+        # Stop de debug session
+        assert self.node.debug_stop() == 0
+        assert self.node.openocd.flash.call_count == 0
+        assert not self.node._in_debug
+
+        # Test with an already flashed firmware
+        self.node.flash(self.node.FW_AUTOTEST)
+        assert self.node.edbg.flash.call_count == 1
+        assert self.node.debug_start() == 0
+        assert self.node.edbg.flash.call_count == 1
+        assert self.node.openocd.flash.call_count == 1
+        self.node.openocd.flash.assert_called_with(self.node._current_fw)
+        assert self.node._current_fw == self.node.FW_AUTOTEST
+        assert self.node._in_debug
+
+        # Stop de debug session
+        assert self.node.debug_stop() == 0
+        assert self.node.openocd.flash.call_count == 1
+        assert not self.node._in_debug

--- a/gateway_code/open_nodes/common/tests/node_openocd_test.py
+++ b/gateway_code/open_nodes/common/tests/node_openocd_test.py
@@ -25,6 +25,7 @@ import unittest
 import serial
 from mock import patch, Mock
 
+from gateway_code.nodes import OpenNodeBase
 from gateway_code.open_nodes.common.node_openocd import NodeOpenOCDBase
 from gateway_code.open_nodes.node_microbit import NodeMicrobit
 
@@ -59,6 +60,11 @@ class TestNodeOpenOCDBase(unittest.TestCase):
 
     def tearDown(self):
         patch.stopall()
+
+    @classmethod
+    def tearDownClass(cls):
+        # Explicitly clear OpenNodeBase registry at the end of all tests.
+        del OpenNodeBase.__registry__[NodeOpenOCDTest.TYPE]
 
     def test_openocd_node_basic(self):
         """Test basic functions of an openocd based node."""

--- a/gateway_code/open_nodes/common/tests/node_openocd_test.py
+++ b/gateway_code/open_nodes/common/tests/node_openocd_test.py
@@ -1,0 +1,114 @@
+# -*- coding:utf-8 -*-
+
+# This file is a part of IoT-LAB gateway_code
+# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Contributor(s) : see AUTHORS file
+#
+# This software is governed by the CeCILL license under French law
+# and abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# http://www.cecill.info.
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+
+""" gateway_code.open_nodes.common.node_openocd unit tests files """
+
+import unittest
+import serial
+from mock import patch, Mock
+
+from gateway_code.open_nodes.common.node_openocd import NodeOpenOCDBase
+from gateway_code.open_nodes.node_microbit import NodeMicrobit
+
+
+class NodeOpenOCDTest(NodeOpenOCDBase):
+    """A test node derived from NodeOpenOCDBase."""
+    TYPE = 'openocd_test'
+    TTY = '/dev/iotlab/ttyTestOpenOCD'
+    BAUDRATE = 115200
+    OPENOCD_CFG_FILE = NodeMicrobit.OPENOCD_CFG_FILE
+    FW_IDLE = NodeMicrobit.FW_IDLE
+    FW_AUTOTEST = NodeMicrobit.FW_AUTOTEST
+
+
+class TestNodeOpenOCDBase(unittest.TestCase):
+    """Unittest class for OpenOCD based open nodes."""
+
+    def setUp(self):
+        self.node = NodeOpenOCDTest()
+        self.fw_path = '/path/to/firmware'
+        openocd_class = patch('gateway_code.utils.openocd.OpenOCD').start()
+        self.node.openocd = openocd_class.return_value
+        self.node.openocd.flash.return_value = 0
+        self.node.openocd.reset.return_value = 0
+        self.node.openocd.flash.return_value = 0
+        self.node.openocd.debug_start.return_value = 0
+        self.node.openocd.debug_stop.return_value = 0
+        self.node.serial_redirection.start = Mock()
+        self.node.serial_redirection.start.return_value = 0
+        self.node.serial_redirection.stop = Mock()
+        self.node.serial_redirection.stop.return_value = 0
+
+    def tearDown(self):
+        patch.stopall()
+
+    def test_openocd_node_basic(self):
+        """Test basic functions of an openocd based node."""
+        # Reset the node
+        assert self.node.reset() == 0
+        self.node.openocd.reset.assert_called_once()
+
+        # Node status always returns 0
+        assert NodeOpenOCDTest.status() == 0
+
+        # debug start
+        assert self.node.debug_start() == 0
+
+        # debug stop
+        assert self.node.debug_stop() == 0
+
+    @patch('serial.Serial')
+    @patch('gateway_code.common.wait_tty')
+    @patch('gateway_code.common.wait_no_tty')
+    def test_openocd_node_flash(self, no_tty, tty, ser):
+        """Test flash function of an openocd based node."""
+        no_tty.return_value = 0
+        tty.return_value = 0
+        # Setup the node
+        assert self.node.setup(self.fw_path) == 0
+        assert self.node.openocd.flash.call_count == 1
+        self.node.openocd.flash.assert_called_with(self.fw_path)
+        assert ser.call_count == 0
+
+        # Teardown the node
+        assert self.node.teardown() == 0
+        self.node.openocd.flash.assert_called_with(self.node.FW_IDLE)
+
+        # Flash a firmware
+        assert self.node.flash(self.fw_path) == 0
+        self.node.openocd.flash.assert_called_with(self.fw_path)
+        assert ser.call_count == 0
+
+        assert self.node.flash() == 0
+        self.node.openocd.flash.assert_called_with(self.node.FW_IDLE)
+        assert ser.call_count == 0
+
+        # Flash with DIRTY_SERIAL attribute
+        # pylint:disable=invalid-name,attribute-defined-outside-init
+        self.node.DIRTY_SERIAL = True
+        assert self.node.flash(self.fw_path) == 0
+        self.node.openocd.flash.assert_called_with(self.fw_path)
+        assert ser.call_count == 1
+
+        # Simulate a serial issue
+        ser.side_effect = serial.serialutil.SerialException
+        assert self.node.flash() == 1
+        self.node.openocd.flash.assert_called_with(self.node.FW_IDLE)

--- a/gateway_code/open_nodes/node_fox.py
+++ b/gateway_code/open_nodes/node_fox.py
@@ -20,28 +20,20 @@
 # knowledge of the CeCILL license and that you accept its terms.
 
 """ Open Node FOX experiment implementation """
-import logging
 
 from gateway_code.config import static_path
-from gateway_code import common
-from gateway_code.common import logger_call
-from gateway_code.nodes import OpenNodeBase
-
-from gateway_code.utils.openocd import OpenOCD
-from gateway_code.utils.serial_redirection import SerialRedirection
-
-LOGGER = logging.getLogger('gateway_code')
+from gateway_code.open_nodes.common.node_openocd import NodeOpenOCDBase
 
 
-class NodeFox(OpenNodeBase):
+class NodeFox(NodeOpenOCDBase):
     """ Open node FOX implementation """
 
     # Contrary to m3 node, fox node need some time to be visible.
     # Also flash/reset may fail after a node start_dc but don't care
     TYPE = 'fox'
-    ELF_TARGET = ('ELFCLASS32', 'EM_ARM')
     TTY = '/dev/iotlab/ttyON_FOX'
     BAUDRATE = 500000
+    OPENOCD_PATH = 'openocd'  # Use old openocd
     OPENOCD_CFG_FILE = static_path('iot-lab-fox.cfg')
     OPENOCD_OPTS = ('target/stm32f1x.cfg',)
     FW_IDLE = static_path('fox_idle.elf')
@@ -56,70 +48,3 @@ class NodeFox(OpenNodeBase):
         # 'leds_consumption', not precise enough
         # (0.886405, [0.886405, 0.886405, 0.886405, 0.887015])
     ]
-
-    ALIM = '5V'
-
-    def __init__(self):
-        self.serial_redirection = SerialRedirection(self.TTY, self.BAUDRATE)
-        self.openocd = OpenOCD.from_node(self)
-
-    @logger_call("Node Fox : Setup of fox node")
-    def setup(self, firmware_path):
-        """ Flash open node, create serial redirection """
-        ret_val = 0
-
-        common.wait_no_tty(self.TTY)
-        ret_val += common.wait_tty(self.TTY, LOGGER)
-        ret_val += self.flash(firmware_path)
-        ret_val += self.serial_redirection.start()
-        return ret_val
-
-    @logger_call("Node Fox : teardown of fox node")
-    def teardown(self):
-        """ Stop serial redirection and flash idle firmware """
-        ret_val = 0
-        # ON may have been stopped at the end of the experiment.
-        # And then restarted again in cn teardown.
-        # This leads to problem where the TTY disappears and reappears during
-        # the first 2 seconds. So let some time if it wants to disappear first.
-        common.wait_no_tty(self.TTY)
-        ret_val += common.wait_tty(self.TTY, LOGGER)
-        # cleanup debugger before flashing
-        ret_val += self.debug_stop()
-        ret_val += self.serial_redirection.stop()
-        ret_val += self.flash(None)
-        return ret_val
-
-    @logger_call("Node Fox : flash of fox node")
-    def flash(self, firmware_path=None):
-        """ Flash the given firmware on FOX node
-
-        :param firmware_path: Path to the firmware to be flashed on `node`.
-                              If None, flash 'idle' firmware.
-        """
-        firmware_path = firmware_path or self.FW_IDLE
-        LOGGER.info('Flash firmware on FOX: %s', firmware_path)
-        return self.openocd.flash(firmware_path)
-
-    @logger_call("Node Fox : reset of fox node")
-    def reset(self):
-        """ Reset the FOX node using jtag """
-        LOGGER.info('Reset FOX node')
-        return self.openocd.reset()
-
-    def debug_start(self):
-        """ Start FOX node debugger """
-        LOGGER.info('FOX Node debugger start')
-        return self.openocd.debug_start()
-
-    def debug_stop(self):
-        """ Stop FOX node debugger """
-        LOGGER.info('FOX Node debugger stop')
-        return self.openocd.debug_stop()
-
-    @staticmethod
-    def status():
-        """ Check FOX node status """
-        # Status is called when open node is not powered
-        # So can't check for FTDI
-        return 0

--- a/gateway_code/open_nodes/node_m3.py
+++ b/gateway_code/open_nodes/node_m3.py
@@ -21,27 +21,19 @@
 
 """ Open Node M3 experiment implementation """
 
-import logging
+from gateway_code.utils.ftdi_check import ftdi_check
 
 from gateway_code.config import static_path
-from gateway_code import common
-from gateway_code.common import logger_call
-from gateway_code.nodes import OpenNodeBase
-
-from gateway_code.utils.ftdi_check import ftdi_check
-from gateway_code.utils.openocd import OpenOCD
-from gateway_code.utils.serial_redirection import SerialRedirection
-
-LOGGER = logging.getLogger('gateway_code')
+from gateway_code.open_nodes.common.node_openocd import NodeOpenOCDBase
 
 
-class NodeM3(OpenNodeBase):
+class NodeM3(NodeOpenOCDBase):
     """ Open node M3 implemenation """
 
     TYPE = 'm3'
-    ELF_TARGET = ('ELFCLASS32', 'EM_ARM')
     TTY = '/dev/iotlab/ttyON_M3'
     BAUDRATE = 500000
+    OPENOCD_PATH = 'openocd'  # Use old openocd
     OPENOCD_CFG_FILE = static_path('iot-lab-m3.cfg')
     OPENOCD_OPTS = ('target/stm32f1x.cfg',)
     FW_IDLE = static_path('m3_idle.elf')
@@ -57,60 +49,6 @@ class NodeM3(OpenNodeBase):
         'leds_consumption',
         'leds_on', 'leds_off', 'leds_blink',
     ]
-
-    def __init__(self):
-        self.serial_redirection = SerialRedirection(self.TTY, self.BAUDRATE)
-        self.openocd = OpenOCD.from_node(self)
-
-    @logger_call("Node M3 : Setup of m3 node")
-    def setup(self, firmware_path):
-        """ Flash open node, create serial redirection """
-        ret_val = 0
-
-        common.wait_no_tty(self.TTY, timeout=0)
-        ret_val += common.wait_tty(self.TTY, LOGGER, timeout=0)
-        ret_val += self.flash(firmware_path)
-        ret_val += self.serial_redirection.start()
-        return ret_val
-
-    @logger_call("Node M3 : teardown of m3 node")
-    def teardown(self):
-        """ Stop serial redirection and flash idle firmware """
-        ret_val = 0
-        common.wait_no_tty(self.TTY, timeout=0)
-        ret_val += common.wait_tty(self.TTY, LOGGER, timeout=0)
-        # cleanup debugger before flashing
-        ret_val += self.debug_stop()
-        ret_val += self.serial_redirection.stop()
-        ret_val += self.flash(None)
-        return ret_val
-
-    @logger_call("Node M3 : flash of m3 node")
-    def flash(self, firmware_path=None):
-        """ Flash the given firmware on M3 node
-
-        :param firmware_path: Path to the firmware to be flashed on `node`.
-                              If None, flash 'idle' firmware.
-        """
-        firmware_path = firmware_path or self.FW_IDLE
-        LOGGER.info('Flash firmware on M3: %s', firmware_path)
-        return self.openocd.flash(firmware_path)
-
-    @logger_call("Node M3 : reset of m3 node")
-    def reset(self):
-        """ Reset the M3 node using jtag """
-        LOGGER.info('Reset M3 node')
-        return self.openocd.reset()
-
-    def debug_start(self):
-        """ Start M3 node debugger """
-        LOGGER.info('M3 Node debugger start')
-        return self.openocd.debug_start()
-
-    def debug_stop(self):
-        """ Stop M3 node debugger """
-        LOGGER.info('M3 Node debugger stop')
-        return self.openocd.debug_stop()
 
     @staticmethod
     def status():

--- a/gateway_code/open_nodes/node_microbit.py
+++ b/gateway_code/open_nodes/node_microbit.py
@@ -20,97 +20,17 @@
 # knowledge of the CeCILL license and that you accept its terms.
 
 """ Open Node Micro:Bit experiment implementation """
-import logging
 
 from gateway_code.config import static_path
-from gateway_code import common
-from gateway_code.common import logger_call
-from gateway_code.nodes import OpenNodeBase
-from gateway_code.utils.openocd import OpenOCD
-
-from gateway_code.utils.serial_redirection import SerialRedirection
-
-LOGGER = logging.getLogger('gateway_code')
+from gateway_code.open_nodes.common.node_openocd import NodeOpenOCDBase
 
 
-class NodeMicrobit(OpenNodeBase):
+class NodeMicrobit(NodeOpenOCDBase):
     """ Open node Micro:Bit implementation """
 
     TYPE = 'microbit'
-    ELF_TARGET = ('ELFCLASS32', 'EM_ARM')
     TTY = '/dev/iotlab/ttyON_CMSIS-DAP'
     BAUDRATE = 115200
     OPENOCD_CFG_FILE = static_path('iot-lab-microbit.cfg')
-    OPENOCD_PATH = '/opt/openocd-0.10.0/bin/openocd'
     FW_IDLE = static_path('microbit_idle.elf')
     FW_AUTOTEST = static_path('microbit_autotest.elf')
-
-    AUTOTEST_AVAILABLE = [
-        'echo', 'get_time',  # mandatory
-        'leds_on', 'leds_off'
-    ]
-
-    ALIM = '5V'
-    FLASH_TIMEOUT = 60  # Got 40 seconds at max with riot gnrc_networking
-
-    def __init__(self):
-        self.serial_redirection = SerialRedirection(self.TTY, self.BAUDRATE)
-        self.openocd = OpenOCD.from_node(self, timeout=self.FLASH_TIMEOUT)
-
-    @logger_call("Node Micro:Bit : Setup of micro:bit node")
-    def setup(self, firmware_path):
-        """ Flash open node, create serial redirection """
-        ret_val = 0
-
-        common.wait_no_tty(self.TTY)
-        ret_val += common.wait_tty(self.TTY, LOGGER)
-        ret_val += self.flash(firmware_path)
-        ret_val += self.serial_redirection.start()
-        return ret_val
-
-    @logger_call("Node Micro:Bit : teardown of micro:bit node")
-    def teardown(self):
-        """ Stop serial redirection and flash idle firmware """
-        ret_val = 0
-        # ON may have been stopped at the end of the experiment.
-        # And then restarted again in cn teardown.
-        # This leads to problem where the TTY disappears and reappears during
-        # the first 2 seconds. So let some time if it wants to disappear first.
-        common.wait_no_tty(self.TTY)
-        ret_val += common.wait_tty(self.TTY, LOGGER)
-        # cleanup debugger before flashing
-        ret_val += self.serial_redirection.stop()
-        ret_val += self.flash(None)
-        return ret_val
-
-    @logger_call("Node Micro:Bit : flash of micro:bit node")
-    def flash(self, firmware_path=None):
-        """ Flash the given firmware on Node Micro:Bit node
-
-        :param firmware_path: Path to the firmware to be flashed on `node`.
-                              If None, flash 'idle' firmware.
-        """
-        firmware_path = firmware_path or self.FW_IDLE
-        LOGGER.info('Flash firmware on Node Micro:Bit : %s', firmware_path)
-        return self.openocd.flash(firmware_path)
-
-    @logger_call("Node Micro:Bit : reset of micro:bit node")
-    def reset(self):
-        """ Reset the Micro:Bit node """
-        LOGGER.info('Reset Micro:Bit node')
-        return self.openocd.reset()
-
-    def debug_start(self):
-        """ Start Micro:Bit node debugger """
-        LOGGER.info('Micro:Bit Node debugger start')
-        return self.openocd.debug_start()
-
-    def debug_stop(self):
-        """ Stop Micro:Bit node debugger """
-        LOGGER.info('Micro:Bit Node debugger stop')
-        return self.openocd.debug_stop()
-
-    @staticmethod
-    def status():
-        """ Check Micro:Bit node status """
-        return 0

--- a/gateway_code/open_nodes/tests/open_nodes_test.py
+++ b/gateway_code/open_nodes/tests/open_nodes_test.py
@@ -72,19 +72,11 @@ def test_missing_overrides():
 def test_registry_open_node():
     """ Verify the open node registry metaclass """
     class MyNode(OpenNodeBase):
+        # pylint:disable=abstract-method
         """Basic empty OpenNode"""
         TYPE = "my_node"
         ELF_TARGET = ('ELFCLASS32', 'EM_ARM')
         AUTOTEST_AVAILABLE = ['echo', 'get_time']
-
-        def setup(self, firmware_path):
-            pass
-
-        def teardown(self):
-            pass
-
-        def status(self):
-            pass
 
     assert open_node_class("my_node") == MyNode
 
@@ -93,25 +85,19 @@ def test_registry_inheritance():
     """ test case for open node that derive from other open nodes """
 
     class BaseOpenNode(OpenNodeBase):
+        # pylint:disable=abstract-method
         """Basic empty OpenNode"""
         TYPE = "base_open_node"
         ELF_TARGET = ('ELFCLASS32', 'EM_ARM')
         AUTOTEST_AVAILABLE = ['echo', 'get_time']
 
-        def setup(self, firmware_path):
-            pass
-
-        def teardown(self):
-            pass
-
-        def status(self):
-            pass
-
     class DerivedOpenNode(BaseOpenNode):
+        # pylint:disable=abstract-method
         """Derivation with normal class inheritance"""
         TYPE = "derived_open_node"
 
     class MixinDerivedOpenNode(BaseOpenNode, OpenNodeBase):
+        # pylint:disable=abstract-method
         """Derivation + OpenNode mixin"""
         TYPE = "mixin_derived_open_node"
 
@@ -120,6 +106,7 @@ def test_registry_inheritance():
     assert open_node_class("mixin_derived_open_node") == MixinDerivedOpenNode
 
     class TypeMissingDerivedOpenNode(BaseOpenNode):
+        # pylint:disable=abstract-method
         """trap with missing TYPE"""
         pass
 

--- a/gateway_code/utils/tests/avrdude_test.py
+++ b/gateway_code/utils/tests/avrdude_test.py
@@ -101,7 +101,7 @@ class TestTriggerBootloader(unittest.TestCase):
         self.tty_prog = '/tmp/test_trigger_tty_prog'
         self._del_tty_prog()
 
-    def teardown(self):
+    def tearDown(self):
         self._del_tty_prog()
 
     def _create_tty_prog(self, *_, **__):

--- a/gateway_code/utils/tests/cli_openocd_test.py
+++ b/gateway_code/utils/tests/cli_openocd_test.py
@@ -69,3 +69,28 @@ class TestsOpenOCDcli(unittest.TestCase):
             self.ocd.reset.return_value = 42
             ret = openocd.main()
             self.assertEquals(ret, 42)
+
+    @mock.patch("signal.pause")
+    def test_debug(self, pause):
+        """ Running command line debug """
+        # Instance of 'object' has no 'debug' member"
+        # pylint:disable=no-member
+
+        args = ['openocd.py', 'debug', 'M3']
+        with mock.patch('sys.argv', args):
+            self.ocd.debug_start.return_value = 0
+            self.ocd.debug_stop.return_value = 0
+            assert openocd.main() == self.ocd.debug_start.return_value
+            assert self.ocd.debug_start.called
+            assert self.ocd.debug_stop.called
+
+            self.ocd.debug_start.return_value = 1
+            assert openocd.main() == self.ocd.debug_start.return_value
+            assert self.ocd.debug_start.called
+            assert self.ocd.debug_stop.called
+
+            pause.side_effect = KeyboardInterrupt
+            self.ocd.debug_start.return_value = 0
+            assert openocd.main() == self.ocd.debug_start.return_value
+            assert self.ocd.debug_start.called
+            assert self.ocd.debug_stop.called

--- a/gateway_code/utils/tests/ftdi_check_test.py
+++ b/gateway_code/utils/tests/ftdi_check_test.py
@@ -59,3 +59,24 @@ class TestFtdiCheck(unittest.TestCase):
             ''')
         self.assertEquals(1, ftdi_check('open', '2232'))
         m_check_output.assert_called_with(['ftdi-devices-list', '-t', '2232'])
+
+    def test_ftdi_list_present(self, m_check_output):
+        """ Test the 'ftdi_check' method with multiple nodes """
+
+        m_check_output.return_value = textwrap.dedent('''\
+            FTx232 devices lister by IoT-LAB
+            Listing FT4232 devices...
+            Found 1 device(s)
+            Device 0:
+                Manufacturer: IoT-LAB
+                Description: ControlNode
+                Serial:
+            Device 1:
+                Manufacturer: IoT-LAB
+                Description: M3
+                Serial:
+            All done, success!
+            ''')
+        self.assertEquals(0, ftdi_check('control', '4232'))
+        self.assertEquals(0, ftdi_check('control', '4232', description='M3'))
+        m_check_output.assert_called_with(['ftdi-devices-list', '-t', '4232'])

--- a/gateway_code/utils/tests/node_connection_test.py
+++ b/gateway_code/utils/tests/node_connection_test.py
@@ -127,6 +127,7 @@ class TestOpenNodeConnection(unittest.TestCase):
 
 
 class TestOpenNodeConnectionErrors(unittest.TestCase):
+    """Test class for node connection errors."""
 
     def test_connection_error(self):
         self.assertRaises(IOError, OpenNodeConnection.try_connect,
@@ -134,5 +135,4 @@ class TestOpenNodeConnectionErrors(unittest.TestCase):
 
     def test_context_manager_error(self):
         with self.assertRaises(RuntimeError):
-            with OpenNodeConnection():
-                self.fail('Should not have entered context manager')
+            OpenNodeConnection().__enter__()

--- a/gateway_code/utils/tests/serial_expect_test.py
+++ b/gateway_code/utils/tests/serial_expect_test.py
@@ -131,3 +131,9 @@ class TestSerialExpect(unittest.TestCase):
         logger.debug.assert_any_call('123')
         logger.debug.assert_any_call('456789')
         logger.debug.assert_called_with('abcd')
+
+    def test_context_manager(self):
+        with serial_expect.SerialExpect('TTY', 1234) as ser:
+            self.read_ret = ['123\n456', '789\n', 'abcd']
+            ret = ser.expect('a.*d')
+            self.assertEquals(ret, 'abcd')


### PR DESCRIPTION
This PR provides several things:
- fix coverage miss in the `avrdude_test` module
- add new test function for the `elftarget` module
- add missing unit tests for the `cc2538` bsl module. For this one I suspect that debug_start and debug_stop cannot be implemented because `cc2538-bsl.py` is not able to launch a gdb server (like openocd). I think the `debug_start/debug_stop` methods should be removed from the cc2538.py module and also from the Firefly open node
- add a new test function for `serial_expect` (for the context manager feature)
- increase the coverage of the `node_connection` module
- add a test function for the debug command of `cli_openocd`
- add basic unit test to the control node no (`cn_no`)
- most important: introduce a new open node base class, `NodeOpenOCDBase` and use it with microbit, jlink, st_link, fox and m3 existing node.
- add unit test for `NodeOpenOCDBase` and `NodeOpenEdbgBase`

Locally I can reach 78% code coverage with the change of this PR but on Travis it should a bit better (between 80% and 85%, because of the control_node_serial source coverage).

Since this PR is touching existing open nodes, it should be first fully tested with integration tests, on all CI nodes.