### PR TITLE
open_nodes: use generic CMSIS DAP serial port for samr21

### DIFF
--- a/bin/rules.d/arduino_zero.rules
+++ b/bin/rules.d/arduino_zero.rules
@@ -2,7 +2,7 @@
 
 # Serial link
 
-SUBSYSTEM=="tty", SUBSYSTEMS=="usb", ENV{ID_VENDOR}=="Atmel_Corp.", ENV{ID_MODEL}=="EDBG_CMSIS-DAP", ENV{ID_USB_INTERFACE_NUM}=="01", SYMLINK+="iotlab/ttyON_ARDUINO_ZERO"
+SUBSYSTEM=="tty", SUBSYSTEMS=="usb", ENV{ID_VENDOR}=="Atmel_Corp.", ENV{ID_MODEL}=="EDBG_CMSIS-DAP", ENV{ID_USB_INTERFACE_NUM}=="01", SYMLINK+="iotlab/ttyON_CMSIS_DAP"
 SUBSYSTEM=="usb", ATTR{idProduct}=="2157", ATTR{idVendor}=="03eb", MODE="0664", GROUP="dialout"
 
 # Flashing interface

--- a/bin/rules.d/cmsis-dap.rules
+++ b/bin/rules.d/cmsis-dap.rules
@@ -1,8 +1,8 @@
-# SAMR21 Node
+# CMSIS DAP Node
 
 # Serial link
 
-SUBSYSTEM=="tty", SUBSYSTEMS=="usb", ENV{ID_VENDOR}=="Atmel_Corp.", ENV{ID_MODEL}=="EDBG_CMSIS-DAP", ENV{ID_USB_INTERFACE_NUM}=="01",  SYMLINK+="iotlab/ttyON_SAMR21"
+SUBSYSTEM=="tty", SUBSYSTEMS=="usb", ENV{ID_VENDOR}=="Atmel_Corp.", ENV{ID_MODEL}=="EDBG_CMSIS-DAP", ENV{ID_USB_INTERFACE_NUM}=="01",  SYMLINK+="iotlab/ttyON_CMSIS_DAP"
 SUBSYSTEM=="usb", ATTR{idProduct}=="2111", ATTR{idVendor}=="03eb", MODE="0664", GROUP="dialout"
 
 # Flashing interface

--- a/gateway_code/open_nodes/common/node_edbg.py
+++ b/gateway_code/open_nodes/common/node_edbg.py
@@ -38,6 +38,7 @@ class NodeEdbgBase(OpenNodeBase):
     """ Open node EDBG implementation """
 
     ELF_TARGET = ('ELFCLASS32', 'EM_ARM')
+    TTY = '/dev/iotlab/ttyON_CMSIS_DAP'
     BAUDRATE = 115200
 
     AUTOTEST_AVAILABLE = [

--- a/gateway_code/open_nodes/node_arduino_zero.py
+++ b/gateway_code/open_nodes/node_arduino_zero.py
@@ -29,7 +29,6 @@ class NodeArduinoZero(NodeEdbgBase):
     """ Open node Arduino Zero implementation """
 
     TYPE = 'arduino_zero'
-    TTY = '/dev/iotlab/ttyON_ARDUINO_ZERO'
     OPENOCD_CFG_FILE = static_path('iot-lab-arduino-zero.cfg')
     FW_IDLE = static_path('arduino-zero_idle.elf')
     FW_AUTOTEST = static_path('arduino-zero_autotest.elf')

--- a/gateway_code/open_nodes/node_samr21.py
+++ b/gateway_code/open_nodes/node_samr21.py
@@ -29,7 +29,6 @@ class NodeSamr21(NodeEdbgBase):
     """ Open node SAMR21 implemention """
 
     TYPE = 'samr21'
-    TTY = '/dev/iotlab/ttyON_SAMR21'
     OPENOCD_CFG_FILE = static_path('iot-lab-samr21.cfg')
     FW_IDLE = static_path('samr21_idle.elf')
     FW_AUTOTEST = static_path('samr21_autotest.elf')


### PR DESCRIPTION
Apparently the debug interface of the SAMR21 is also something generic, like DAPLink, JLink of STLink.  For this board, it's CMSIS-DAP.

This PR updates the Edbg open node with a new TTY path and also change the associated udev rule.