### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,10 +121,6 @@ RUN git clone https://github.com/JelmerT/cc2538-bsl && \
     apt-get install -y python-pip binutils && \
     pip install intelhex
 
-# pyOCD for micro:bit
-RUN pip install -U pip setuptools && \
-    pip install pyOCD
-
 WORKDIR /setup_dir
 COPY . /setup_dir/
 RUN python setup.py install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 MAINTAINER Cédric Roussel <cedric.roussel@inria.fr>
 
 # This file is a part of IoT-LAB gateway_code
@@ -73,7 +73,7 @@ RUN git clone https://github.com/mytestbed/oml.git && \
     ./configure --disable-doc --disable-doxygen-doc --disable-doxygen-dot \ 
         --disable-android --disable-doxygen-html --disable-option-checking && \
     make && \
-    sudo make install && \
+    make install && \
     cd .. && rm -rf oml
 
 #openocd install (for M3 and SAMR21)
@@ -84,7 +84,7 @@ RUN git clone https://github.com/ntfreak/openocd && \
     ./configure  --enable-legacy-ft2232_libftdi --disable-ftdi2232 \
         --disable-ftd2xx --enable-cmsis-dap --enable-hidapi-libusb && \
     make && \
-    sudo make install && \
+    make install && \
     cd .. && rm -rf openocd
 
 #openocd 0.10
@@ -94,7 +94,7 @@ RUN git clone https://github.com/ntfreak/openocd openocd10 && \
     ./bootstrap && \
     ./configure --prefix=/opt/openocd-0.10.0 --enable-cmsis-dap --enable-hidapi-libusb && \
     make && \
-    sudo make install && \
+    make install && \
     cd .. && rm -rf openocd10
 
 # edbg

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -21,11 +21,11 @@ FROM iot-lab-gateway
 
 # Update
 RUN apt-get update && \
-    apt-get install -y python-pip valgrind gdb
+    apt-get install -y sudo python-pip valgrind gdb
 
 # Install app dependencies
-RUN pip install --upgrade pip && \
-    pip install tox
+RUN sudo pip install --upgrade pip && \
+    sudo pip install tox
 
 RUN apt-get -y --no-install-recommends install \
     ca-certificates \


### PR DESCRIPTION
This PR fixes the build of the docker image:
- The ubuntu base image is 14.04 and his git version cannot clone the openocd submodules. It has been bumped to 16.04
- With 16.04 there's no need to call admin commands with sudo
- PyOCD is not used anymore with micro:bit, we use openocd for this board, so the rule for PyOCD has been removed.