### PR TITLE
nodes: fix import error when using openocd_cmd

### DIFF
--- a/gateway_code/nodes.py
+++ b/gateway_code/nodes.py
@@ -116,7 +116,10 @@ def import_all_nodes(pkg_dir):
     for (module_loader, name, _) in pkgutil.iter_modules([pkg_dir]):
         if name in ['tests', 'common']:
             continue
-        module_loader.find_module(name).load_module(name)
+        try:
+            module_loader.find_module(name).load_module(name)
+        except ImportError:
+            pass
 
 
 import_all_nodes('open_nodes')


### PR DESCRIPTION
Fixes #77 

Tested on a M3 gateway and `openocd_cmd` works with this fix.