### PR TITLE
utils/openocd_cmd: add support for all available open nodes

### DIFF
--- a/gateway_code/nodes.py
+++ b/gateway_code/nodes.py
@@ -116,10 +116,7 @@ def import_all_nodes(pkg_dir):
     for (module_loader, name, _) in pkgutil.iter_modules([pkg_dir]):
         if name in ['tests', 'common']:
             continue
-        try:
-            module_loader.find_module(name).load_module(name)
-        except ImportError:
-            pass
+        module_loader.find_module(name).load_module(name)
 
 
 import_all_nodes('open_nodes')

--- a/gateway_code/utils/cli/avrdude.py
+++ b/gateway_code/utils/cli/avrdude.py
@@ -28,35 +28,30 @@ Usage:
 
 """
 import argparse
-from .. import avrdude
-from . import log_to_stderr
 
-PARSER = argparse.ArgumentParser()
-_SUB = PARSER.add_subparsers()
-
-_FLASH = _SUB.add_parser('flash')
-_FLASH.set_defaults(cmd='flash')
-_FLASH.add_argument('node', type=str, choices=('LEONARDO', 'ZIGDUINO'),)
-_FLASH.add_argument('firmware', type=str, help="Firmware name")
+from gateway_code.nodes import open_node_class
+from gateway_code.utils import avrdude
+from gateway_code.utils.cli import log_to_stderr
 
 
-def _node_type(node):
-    """ Get node avrdude config for 'node' in ('LEONARDO', 'ZIGDUINO') """
-    from gateway_code.open_nodes.node_leonardo import NodeLeonardo
-    from gateway_code.open_nodes.node_zigduino import NodeZigduino
-    _config = {
-        'LEONARDO': NodeLeonardo,
-        'ZIGDUINO': NodeZigduino,
-    }
-    return _config[node]
+def _setup_parser():
+    parser = argparse.ArgumentParser()
+    sub_parser = parser.add_subparsers()
+
+    flash = sub_parser.add_parser('flash')
+    flash.set_defaults(cmd='flash')
+    flash.add_argument('node', type=str, choices=('LEONARDO', 'ZIGDUINO'))
+    flash.add_argument('firmware', type=str, help="Firmware name")
+    return parser
 
 
 @log_to_stderr
 def main():
     """ openocd main function """
 
-    opts = PARSER.parse_args()
-    node = _node_type(opts.node)
+    parser = _setup_parser()
+    opts = parser.parse_args()
+    node = open_node_class(opts.node.lower())
     ret = 0
     if opts.node == 'LEONARDO':
         ret += avrdude.AvrDude.trigger_bootloader(node.TTY, node.TTY_PROG)

--- a/gateway_code/utils/cli/openocd.py
+++ b/gateway_code/utils/cli/openocd.py
@@ -29,40 +29,51 @@ Usage:
 """
 import signal
 import argparse
-from .. import openocd
-from . import log_to_stderr
+
+from gateway_code.control_nodes.cn_iotlab import ControlNodeIotlab
+from gateway_code.open_nodes.node_m3 import NodeM3
+from gateway_code.open_nodes.node_fox import NodeFox
+from gateway_code.open_nodes.node_samr21 import NodeSamr21
+from gateway_code.open_nodes.node_samr30 import NodeSamr30
+from gateway_code.open_nodes.node_st_lrwan1 import NodeStLrwan1
+from gateway_code.open_nodes.node_st_iotnode import NodeStIotnode
+from gateway_code.open_nodes.node_arduino_zero import NodeArduinoZero
+from gateway_code.open_nodes.node_microbit import NodeMicrobit
+from gateway_code.open_nodes.node_nrf52dk import NodeNrf52Dk
+from gateway_code.open_nodes.node_nrf52840dk import NodeNrf52840Dk
+
+from gateway_code.utils import openocd
+from gateway_code.utils.cli import log_to_stderr
+
+_NODES = {
+    'CN': ControlNodeIotlab,
+    'M3': NodeM3,
+    'FOX': NodeFox,
+    'SAMR21': NodeSamr21,
+    'SAMR30': NodeSamr30,
+    'ST-LRWAN1': NodeStLrwan1,
+    'ST-IOTNODE': NodeStIotnode,
+    'ARDUINO-ZERO': NodeArduinoZero,
+    'MICROBIT': NodeMicrobit,
+    'NRF52DK': NodeNrf52Dk,
+    'NRF52840': NodeNrf52840Dk
+}
 
 PARSER = argparse.ArgumentParser()
 _SUB = PARSER.add_subparsers()
 
 _FLASH = _SUB.add_parser('flash')
 _FLASH.set_defaults(cmd='flash')
-_FLASH.add_argument('node', type=str, choices=('CN', 'M3', 'FOX', 'SAMR21'),)
+_FLASH.add_argument('node', type=str, choices=_NODES.keys())
 _FLASH.add_argument('firmware', type=str, help="Firmware name")
 
 _RESET = _SUB.add_parser('reset')
 _RESET.set_defaults(cmd='reset')
-_RESET.add_argument('node', type=str, choices=('CN', 'M3', 'FOX', 'SAMR21'))
+_RESET.add_argument('node', type=str, choices=_NODES.keys())
 
 _DEBUG = _SUB.add_parser('debug')
 _DEBUG.set_defaults(cmd='debug')
-_DEBUG.add_argument('node', type=str, choices=('CN', 'M3', 'FOX'))
-
-
-def _node_class(node):
-    """ Get node openocd config for 'node' in ('CN', 'M3', 'FOX', 'SAMR21') """
-    # This is a HACK for the moment, nodes should be deduced otherwise
-    from gateway_code.open_nodes.node_m3 import NodeM3
-    from gateway_code.open_nodes.node_fox import NodeFox
-    from gateway_code.open_nodes.node_samr21 import NodeSamr21
-    from gateway_code.control_nodes.cn_iotlab import ControlNodeIotlab
-    _config_files = {
-        'CN': ControlNodeIotlab,
-        'M3': NodeM3,
-        'FOX': NodeFox,
-        'SAMR21': NodeSamr21,
-    }
-    return _config_files[node]
+_DEBUG.add_argument('node', type=str, choices=_NODES.keys())
 
 
 def _debug(ocd):
@@ -84,7 +95,7 @@ def _debug(ocd):
 def main():
     """ openocd main function """
     opts = PARSER.parse_args()
-    node = _node_class(opts.node)
+    node = _NODES[opts.node]
     ocd = openocd.OpenOCD.from_node(node, verb=True)
 
     if opts.cmd == 'reset':


### PR DESCRIPTION
This PR allows to easily flash any kind of open nodes that support openocd from a gateway.