### PR TITLE
Tools

### DIFF
--- a/gateway_code/utils/tests/avrdude_test.py
+++ b/gateway_code/utils/tests/avrdude_test.py
@@ -28,7 +28,6 @@
 # pylint: disable=maybe-no-member
 # pylint: disable=unused-argument
 
-import time
 import os.path
 import unittest
 
@@ -59,37 +58,6 @@ class TestsMethods(unittest.TestCase):
     def test_invalid_firmware_path(self):
         ret = self.avr.flash('/invalid/path')
         self.assertNotEqual(0, ret)
-
-
-class TestsCall(unittest.TestCase):
-    """ Tests avrdude call timeout """
-    def setUp(self):
-        self.timeout = 5
-        self.avr = avrdude.AvrDude(NodeLeonardo.AVRDUDE_CONF,
-                                   timeout=self.timeout)
-        self.avr.args = mock.Mock()
-
-    def test_timeout_call(self):
-        """Test timeout reached."""
-        self.avr.args.return_value = {'args': ['sleep', '10']}
-        t_0 = time.time()
-        ret = self.avr.call_cmd('sleep')
-        t_end = time.time()
-
-        # Not to much more
-        self.assertLess(t_end - t_0, self.timeout + 1)
-        self.assertNotEqual(ret, 0)
-
-    def test_no_timeout(self):
-        """Test timeout not reached."""
-        self.avr.args.return_value = {'args': ['sleep', '1']}
-        t_0 = time.time()
-        ret = self.avr.call_cmd('sleep')
-        t_end = time.time()
-
-        # Strictly lower here
-        self.assertLess(t_end - t_0, self.timeout - 1)
-        self.assertEqual(ret, 0)
 
 
 @mock.patch('serial.Serial')

--- a/gateway_code/utils/tests/avrdude_test.py
+++ b/gateway_code/utils/tests/avrdude_test.py
@@ -67,13 +67,13 @@ class TestsCall(unittest.TestCase):
         self.timeout = 5
         self.avr = avrdude.AvrDude(NodeLeonardo.AVRDUDE_CONF,
                                    timeout=self.timeout)
-        self.avr._avrdude_args = mock.Mock()
+        self.avr.args = mock.Mock()
 
     def test_timeout_call(self):
         """Test timeout reached."""
-        self.avr._avrdude_args.return_value = {'args': ['sleep', '10']}
+        self.avr.args.return_value = {'args': ['sleep', '10']}
         t_0 = time.time()
-        ret = self.avr._call_cmd('sleep')
+        ret = self.avr.call_cmd('sleep')
         t_end = time.time()
 
         # Not to much more
@@ -82,9 +82,9 @@ class TestsCall(unittest.TestCase):
 
     def test_no_timeout(self):
         """Test timeout not reached."""
-        self.avr._avrdude_args.return_value = {'args': ['sleep', '1']}
+        self.avr.args.return_value = {'args': ['sleep', '1']}
         t_0 = time.time()
-        ret = self.avr._call_cmd('sleep')
+        ret = self.avr.call_cmd('sleep')
         t_end = time.time()
 
         # Strictly lower here

--- a/gateway_code/utils/tests/cc2538_test.py
+++ b/gateway_code/utils/tests/cc2538_test.py
@@ -21,7 +21,6 @@
 """" some tests for the CC2538 wrapper"""
 
 import os
-import time
 import unittest
 
 import mock
@@ -78,36 +77,3 @@ class TestsCC2538Methods(unittest.TestCase):
         """Test flash an invalid firmware return a non zero value."""
         ret = self.cc2538.flash('/invalid/path')
         assert ret > 0
-
-
-class TestsCC2538Call(unittest.TestCase):
-    # pylint:disable=protected-access
-    """ Tests cc2538-bsl call timeout """
-    def setUp(self):
-        self.timeout = 5
-        self.cc2538 = cc2538.CC2538({'port': NodeFirefly.TTY,
-                                     'baudrate': NodeFirefly.BAUDRATE},
-                                    timeout=self.timeout)
-        self.cc2538.args = mock.Mock()
-
-    def test_timeout_call(self):
-        """Test timeout reached."""
-        self.cc2538.args.return_value = {'args': ['sleep', '10']}
-        t_0 = time.time()
-        ret = self.cc2538.call_cmd('sleep')
-        t_end = time.time()
-
-        # Not to much more
-        self.assertLess(t_end - t_0, self.timeout + 1)
-        self.assertNotEqual(ret, 0)
-
-    def test_no_timeout(self):
-        """Test timeout not reached."""
-        self.cc2538.args.return_value = {'args': ['sleep', '1']}
-        t_0 = time.time()
-        ret = self.cc2538.call_cmd('sleep')
-        t_end = time.time()
-
-        # Strictly lower here
-        self.assertLess(t_end - t_0, self.timeout - 1)
-        self.assertEqual(ret, 0)

--- a/gateway_code/utils/tests/cc2538_test.py
+++ b/gateway_code/utils/tests/cc2538_test.py
@@ -88,13 +88,13 @@ class TestsCC2538Call(unittest.TestCase):
         self.cc2538 = cc2538.CC2538({'port': NodeFirefly.TTY,
                                      'baudrate': NodeFirefly.BAUDRATE},
                                     timeout=self.timeout)
-        self.cc2538._cc2538_args = mock.Mock()
+        self.cc2538.args = mock.Mock()
 
     def test_timeout_call(self):
         """Test timeout reached."""
-        self.cc2538._cc2538_args.return_value = {'args': ['sleep', '10']}
+        self.cc2538.args.return_value = {'args': ['sleep', '10']}
         t_0 = time.time()
-        ret = self.cc2538._call_cmd('sleep')
+        ret = self.cc2538.call_cmd('sleep')
         t_end = time.time()
 
         # Not to much more
@@ -103,9 +103,9 @@ class TestsCC2538Call(unittest.TestCase):
 
     def test_no_timeout(self):
         """Test timeout not reached."""
-        self.cc2538._cc2538_args.return_value = {'args': ['sleep', '1']}
+        self.cc2538.args.return_value = {'args': ['sleep', '1']}
         t_0 = time.time()
-        ret = self.cc2538._call_cmd('sleep')
+        ret = self.cc2538.call_cmd('sleep')
         t_end = time.time()
 
         # Strictly lower here

--- a/gateway_code/utils/tests/edbg_test.py
+++ b/gateway_code/utils/tests/edbg_test.py
@@ -27,7 +27,6 @@
 # pylint: disable=maybe-no-member
 # pylint: disable=unused-argument
 
-import time
 import unittest
 
 import mock
@@ -57,33 +56,3 @@ class TestsMethods(unittest.TestCase):
     def test_invalid_firmware_path(self):
         ret = self.edbg.flash('/invalid/path')
         self.assertNotEqual(0, ret)
-
-
-class TestsCall(unittest.TestCase):
-    """ Tests edbg call timeout """
-    def setUp(self):
-        self.timeout = 5
-        self.edbg = edbg.Edbg(timeout=self.timeout)
-        self.edbg.args = mock.Mock()
-
-    def test_timeout_call(self):
-        """Test timeout reached."""
-        self.edbg.args.return_value = {'args': ['sleep', '10']}
-        t_0 = time.time()
-        ret = self.edbg.call_cmd('sleep')
-        t_end = time.time()
-
-        # Not to much more
-        self.assertLess(t_end - t_0, self.timeout + 1)
-        self.assertNotEqual(ret, 0)
-
-    def test_no_timeout(self):
-        """Test timeout not reached."""
-        self.edbg.args.return_value = {'args': ['sleep', '1']}
-        t_0 = time.time()
-        ret = self.edbg.call_cmd('sleep')
-        t_end = time.time()
-
-        # Strictly lower here
-        self.assertLess(t_end - t_0, self.timeout - 1)
-        self.assertEqual(ret, 0)

--- a/gateway_code/utils/tests/edbg_test.py
+++ b/gateway_code/utils/tests/edbg_test.py
@@ -64,13 +64,13 @@ class TestsCall(unittest.TestCase):
     def setUp(self):
         self.timeout = 5
         self.edbg = edbg.Edbg(timeout=self.timeout)
-        self.edbg._edbg_args = mock.Mock()
+        self.edbg.args = mock.Mock()
 
     def test_timeout_call(self):
         """Test timeout reached."""
-        self.edbg._edbg_args.return_value = {'args': ['sleep', '10']}
+        self.edbg.args.return_value = {'args': ['sleep', '10']}
         t_0 = time.time()
-        ret = self.edbg._call_cmd('sleep')
+        ret = self.edbg.call_cmd('sleep')
         t_end = time.time()
 
         # Not to much more
@@ -79,9 +79,9 @@ class TestsCall(unittest.TestCase):
 
     def test_no_timeout(self):
         """Test timeout not reached."""
-        self.edbg._edbg_args.return_value = {'args': ['sleep', '1']}
+        self.edbg.args.return_value = {'args': ['sleep', '1']}
         t_0 = time.time()
-        ret = self.edbg._call_cmd('sleep')
+        ret = self.edbg.call_cmd('sleep')
         t_end = time.time()
 
         # Strictly lower here

--- a/gateway_code/utils/tests/openocd_test.py
+++ b/gateway_code/utils/tests/openocd_test.py
@@ -108,13 +108,13 @@ class TestsCall(unittest.TestCase):
     def setUp(self):
         self.timeout = 5
         self.ocd = openocd.OpenOCD.from_node(NodeM3, timeout=self.timeout)
-        self.ocd._openocd_args = mock.Mock()
+        self.ocd.args = mock.Mock()
 
     def test_timeout_call(self):
         """Test timeout reached."""
-        self.ocd._openocd_args.return_value = {'args': ['sleep', '10']}
+        self.ocd.args.return_value = {'args': ['sleep', '10']}
         t_0 = time.time()
-        ret = self.ocd._call_cmd('sleep')
+        ret = self.ocd.call_cmd('sleep')
         t_end = time.time()
 
         # Not to much more
@@ -123,9 +123,9 @@ class TestsCall(unittest.TestCase):
 
     def test_no_timeout(self):
         """Test timeout not reached."""
-        self.ocd._openocd_args.return_value = {'args': ['sleep', '1']}
+        self.ocd.args.return_value = {'args': ['sleep', '1']}
         t_0 = time.time()
-        ret = self.ocd._call_cmd('sleep')
+        ret = self.ocd.call_cmd('sleep')
         t_end = time.time()
 
         # Strictly lower here

--- a/gateway_code/utils/tests/openocd_test.py
+++ b/gateway_code/utils/tests/openocd_test.py
@@ -27,7 +27,6 @@
 # serial mock note correctly detected
 # pylint: disable=maybe-no-member
 
-import time
 import unittest
 import mock
 
@@ -101,36 +100,6 @@ class TestsMethods(unittest.TestCase):
         self.ocd.debug_start()
         ret = self.ocd.debug_stop()
         self.assertEqual(ret, 1)
-
-
-class TestsCall(unittest.TestCase):
-    """ Tests openocd call timeout """
-    def setUp(self):
-        self.timeout = 5
-        self.ocd = openocd.OpenOCD.from_node(NodeM3, timeout=self.timeout)
-        self.ocd.args = mock.Mock()
-
-    def test_timeout_call(self):
-        """Test timeout reached."""
-        self.ocd.args.return_value = {'args': ['sleep', '10']}
-        t_0 = time.time()
-        ret = self.ocd.call_cmd('sleep')
-        t_end = time.time()
-
-        # Not to much more
-        self.assertLess(t_end - t_0, self.timeout + 1)
-        self.assertNotEqual(ret, 0)
-
-    def test_no_timeout(self):
-        """Test timeout not reached."""
-        self.ocd.args.return_value = {'args': ['sleep', '1']}
-        t_0 = time.time()
-        ret = self.ocd.call_cmd('sleep')
-        t_end = time.time()
-
-        # Strictly lower here
-        self.assertLess(t_end - t_0, self.timeout - 1)
-        self.assertEqual(ret, 0)
 
 
 class TestsFlashInvalidPaths(unittest.TestCase):

--- a/gateway_code/utils/tests/tools_test.py
+++ b/gateway_code/utils/tests/tools_test.py
@@ -1,0 +1,59 @@
+# -*- coding:utf-8 -*-
+
+# This file is a part of IoT-LAB gateway_code
+# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Contributor(s) : see AUTHORS file
+#
+# This software is governed by the CeCILL license under French law
+# and abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# http://www.cecill.info.
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+
+""" tests for utils/tools FlashTool """
+
+import time
+import unittest
+
+from mock import mock
+
+from gateway_code.utils.tools import FlashTool
+
+
+class TestsCall(unittest.TestCase):
+    """ Tests FlashTool call timeout """
+    def setUp(self):
+        self.timeout = 5
+        self.tool = FlashTool(timeout=self.timeout)
+        self.tool.args = mock.Mock()
+
+    def test_timeout_call(self):
+        """Test timeout reached."""
+        self.tool.args.return_value = {'args': ['sleep', '10']}
+        t_0 = time.time()
+        ret = self.tool.call_cmd('sleep')
+        t_end = time.time()
+
+        # Not to much more
+        self.assertLess(t_end - t_0, self.timeout + 1)
+        self.assertNotEquals(ret, 0)
+
+    def test_no_timeout(self):
+        """Test timeout not reached."""
+        self.tool.args.return_value = {'args': ['sleep', '1']}
+        t_0 = time.time()
+        ret = self.tool.call_cmd('sleep')
+        t_end = time.time()
+
+        # Strictly lower here
+        self.assertLess(t_end - t_0, self.timeout - 1)
+        self.assertEquals(ret, 0)

--- a/gateway_code/utils/tools.py
+++ b/gateway_code/utils/tools.py
@@ -1,0 +1,60 @@
+# -*- coding:utf-8 -*-
+
+# This file is a part of IoT-LAB gateway_code
+# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Contributor(s) : see AUTHORS file
+#
+# This software is governed by the CeCILL license under French law
+# and abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# http://www.cecill.info.
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+
+""" common code for flash/debug tools """
+
+import logging
+import os
+import shlex
+
+from gateway_code.utils import subprocess_timeout
+
+LOGGER = logging.getLogger('gateway_code')
+
+
+class FlashTool(object):
+    """ common class for flash/debug tools """
+    TIMEOUT = 100
+
+    DEVNULL = open(os.devnull, 'w')
+
+    def __init__(self, verb=False, timeout=TIMEOUT):
+        self.out = None if verb else self.DEVNULL
+        self.timeout = timeout
+        self.name = self.__class__.__name__
+
+    def args(self, command_str):
+        """splits a command into arguments for Popen"""
+
+        args = shlex.split(command_str)
+        return {'args': args, 'stdout': self.out, 'stderr': self.out}
+
+    def call_cmd(self, command_str):
+        """ Run the given command_str."""
+
+        kwargs = self.args(command_str)
+        LOGGER.info(kwargs)
+
+        try:
+            return subprocess_timeout.call(timeout=self.timeout, **kwargs)
+        except subprocess_timeout.TimeoutExpired as exc:
+            LOGGER.error("%s '%s' timeout: %s", self.name, command_str, exc)
+            return 1

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -31,7 +31,16 @@ RUN apt-get -y --no-install-recommends install \
     ca-certificates \
     curl
 
-RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+RUN export KEY=B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+    for server in $(shuf -e ha.pool.sks-keyservers.net \
+                            hkp://p80.pool.sks-keyservers.net:80 \
+                            keyserver.ubuntu.com \
+                            hkp://keyserver.ubuntu.com:80 \
+                            keyserver.pgp.com \
+                            pgp.mit.edu) ; do \
+        gpg --batch --keyserver "$server" --recv-keys $KEY && break || : ; \
+    done;
+
 RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.4/gosu-$(dpkg --print-architecture)" \
     && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.4/gosu-$(dpkg --print-architecture).asc" \
     && gpg --verify /usr/local/bin/gosu.asc \


### PR DESCRIPTION
re-reading the code because I was trying to fix firefly flashing bug I found the amount of time we did a dance around subprocess.Popen/call/output/stdout quite high, especially when we have many flashing tools, and they all do the same thing. 

- This PR creates a `Tool` class from which all derive (OpenOcd, Edbg, Avrdude, CC2538)
- This `Tool` class uses subprocess.check_output instead of subprocess.call to get the stdout/stderr of the subprocess, and display it in some cases: for all cases, when verbose is True, or only in case the tool returns an error (return code !=0). 

AFAIK, tests were green (probably still some linting |-) ). But I'm still in the process of validating that this doesn't break integration tests for all the boards.

4a6bfb6 is unrelated, the usual discussion with --cov in tox.ini instead of setup.cfg