### PR TITLE
tox: refactor config file

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,10 +15,9 @@ whitelist_externals =
     /usr/bin/make
 deps = -rtests_utils/test-requirements.txt
 commands =
-    pytest -s --pep8 --cov=gateway_code --cov-report=xml --cov-report=term --cov-report=term-missing --junitxml results.xml {posargs}
-    # Get rid of pytest ImportMismatchError for future runs (either locally
-    # or via docker)
-    make clean-test-files
+    {[testenv:pytest]commands} -s --pep8 {posargs}
+commands_post =
+    {[testenv:clean_test_files]commands}
 
 
 [testenv:upload_coverage]
@@ -52,14 +51,14 @@ commands =
     # Tests should be run as user 'www-data'
     bash -c "test {env:USER} == www-data"
     bash -c "python setup.py build_ext"  # build control_node_serial
-    bash -c "pytest -s -x {posargs}"     # run the full test suite
+    # run the full test suite with coverage
+    bash -c "{[testenv:pytest]commands} -s -x {posargs}"
     # Run codecov command if passed via environment variable, otherwise do
     # nothing.
     # codecov command should be in the form: codecov -t <codecov_token>
     {env:CODECOV_CMD:echo -n}
-    # Get rid of pytest ImportMismatchError for future runs (either locally
-    # or via docker)
-    make clean-test-files
+commands_post =
+    {[testenv:clean_test_files]commands}
 
 
 [testenv:local]
@@ -72,7 +71,20 @@ commands =
              export IOTLAB_GATEWAY_CFG_DIR={posargs:tests_utils/cfg_dir/}; \
              fi; \
              export IOTLAB_USERS=/tmp/users;\
-             pytest --pep8 -x"
+             {[testenv:pytest]commands} --pep8 -x {posargs}"
+commands_post =
+    {[testenv:clean_test_files]commands}
+
+
+[testenv:pytest]
+# Shared pytest command
+commands = pytest --cov=gateway_code --cov-report=xml --cov-report=term --cov-report=term-missing
+
+
+[testenv:clean_test_files]
+whitelist_externals =
+    /usr/bin/make
+commands =
     # Get rid of pytest ImportMismatchError for future runs (either locally
     # or via docker)
     make clean-test-files


### PR DESCRIPTION
- use a shared pytest testenv and fix broken coverage report on integration nodes
- use a shared clean files testenv

I just want to have this tested by travis before merging it but otherwise it already works on integration nodes and locally.