### PR TITLE
open_nodes: add verify method in OpenNodeBase class

### DIFF
--- a/gateway_code/nodes.py
+++ b/gateway_code/nodes.py
@@ -19,6 +19,8 @@
 # The fact that you are presently reading this means that you have had
 # knowledge of the CeCILL license and that you accept its terms.
 
+# pylint: disable=no-member
+
 """ Common logic for plugin nodes classes """
 import abc
 import os

--- a/gateway_code/nodes.py
+++ b/gateway_code/nodes.py
@@ -115,20 +115,21 @@ class OpenNodeBase(object):
         """ Verifiy the open node """
         ret_val = 0
         # Tuple with (class, machine) run 'elftarget.py' on a node firmware
-        if getattr(cls, 'ELF_TARGET', None) is None or \
-           len(cls.ELF_TARGET) != 2:
+        if (getattr(cls, 'ELF_TARGET', None) is None or
+                len(cls.ELF_TARGET) != 2):
             ret_val += 1
 
         for firmware_attr in ('FW_IDLE', 'FW_AUTOTEST'):
             firmware = getattr(cls, firmware_attr, None)
-            if firmware and \
-               not elftarget.is_compatible_with_node(firmware, cls):
+            if (firmware is not None and not
+                    elftarget.is_compatible_with_node(firmware, cls)):
                 ret_val += 1
 
         required_autotest = {'echo', 'get_time'}  # mandatory
-        if getattr(cls, 'AUTOTEST_AVAILABLE', None) is None or \
-           not required_autotest.issubset(cls.AUTOTEST_AVAILABLE):
+        if (getattr(cls, 'AUTOTEST_AVAILABLE', None) is None or
+                not required_autotest.issubset(cls.AUTOTEST_AVAILABLE)):
             ret_val += 1
+
         return ret_val
 
 
@@ -165,7 +166,9 @@ def open_node_class(board_type):
 
     :raises ValueError: if board class can't be found """
     output_class = _node_class(OpenNodeBase, board_type)
-    assert output_class.verify() == 0
+    if output_class.verify() != 0:
+        raise ValueError('Invalid open node class {}'.format(
+            output_class.__name__))
     return output_class
 
 

--- a/gateway_code/nodes.py
+++ b/gateway_code/nodes.py
@@ -110,20 +110,24 @@ class OpenNodeBase(object):
         """ Status of the node """
         pass  # pragma: no cover
 
-    def verify(self):
+    @classmethod
+    def verify(cls):
         """ Verifiy the open node """
         ret_val = 0
         # Tuple with (class, machine) run 'elftarget.py' on a node firmware
-        if len(self.ELF_TARGET) != 2:
+        if getattr(cls, 'ELF_TARGET', None) is None or \
+           len(cls.ELF_TARGET) != 2:
             ret_val += 1
 
         for firmware_attr in ('FW_IDLE', 'FW_AUTOTEST'):
-            firmware = getattr(self, firmware_attr, None)
-            if not elftarget.is_compatible_with_node(firmware, self):
+            firmware = getattr(cls, firmware_attr, None)
+            if firmware and \
+               not elftarget.is_compatible_with_node(firmware, cls):
                 ret_val += 1
 
         required_autotest = {'echo', 'get_time'}  # mandatory
-        if not required_autotest.issubset(self.AUTOTEST_AVAILABLE):
+        if getattr(cls, 'AUTOTEST_AVAILABLE', None) is None or \
+           not required_autotest.issubset(cls.AUTOTEST_AVAILABLE):
             ret_val += 1
         return ret_val
 
@@ -161,7 +165,7 @@ def open_node_class(board_type):
 
     :raises ValueError: if board class can't be found """
     output_class = _node_class(OpenNodeBase, board_type)
-    assert output_class().verify() == 0
+    assert output_class.verify() == 0
     return output_class
 
 

--- a/gateway_code/open_nodes/tests/open_nodes_test.py
+++ b/gateway_code/open_nodes/tests/open_nodes_test.py
@@ -80,22 +80,6 @@ def test_registry_open_node():
         ELF_TARGET = ('ELFCLASS32', 'EM_ARM')
         AUTOTEST_AVAILABLE = ['echo', 'get_time']
 
-        def setup(self, firmware_path):
-            """ Setup the open node with a firmware"""
-            return 0
-
-        def teardown(self):
-            """ Cleanup the open node """
-            return 0
-
-        def status(self):
-            """ Status of the node """
-            return 0
-
-        def verify(self):
-            """ Verify the open node """
-            return 0
-
     assert open_node_class("my_node") == MyNode
 
     with pytest.raises(ValueError):
@@ -127,22 +111,6 @@ def test_registry_inheritance():
         TYPE = "base_open_node"
         ELF_TARGET = ('ELFCLASS32', 'EM_ARM')
         AUTOTEST_AVAILABLE = ['echo', 'get_time']
-
-        def setup(self, firmware_path):
-            """ Setup the open node with a firmware"""
-            return 0
-
-        def teardown(self):
-            """ Cleanup the open node """
-            return 0
-
-        def status(self):
-            """ Status of the node """
-            return 0
-
-        def verify(self):
-            """ Verify the open node """
-            return 0
 
     class DerivedOpenNode(BaseOpenNode):
         # pylint:disable=abstract-method
@@ -218,7 +186,7 @@ def test_open_node_inheritance():
     assert board_instance.status() == 0
 
 
-def test_open_node_verify():
+def test_node_verify():
     """
         test case for verify open node method
     """
@@ -232,19 +200,23 @@ def test_open_node_verify():
         FW_IDLE = static_path('m3_idle.elf')
         FW_AUTOTEST = static_path('m3_autotest.elf')
 
-        def setup(self, firmware_path):
-            """ Setup the open node with a firmware"""
-            return 0
+    board = open_node_class("base_open_node")
+    assert board == BaseOpenNode
 
-        def teardown(self):
-            """ Cleanup the open node """
-            return 0
 
-        def status(self):
-            """ Status of the node """
+def test_node_verify_inheritance():
+    """
+        test case for verify open node method with inheritance
+    """
+
+    class BaseOpenNode(OpenNodeBase):
+        # pylint:disable=abstract-method
+        """Basic empty OpenNode"""
+        TYPE = "base_open_node"
+
+        @classmethod
+        def verify(cls):
             return 0
 
     board = open_node_class("base_open_node")
     assert board == BaseOpenNode
-    board_instance = board()
-    assert board_instance.verify() == 0

--- a/gateway_code/open_nodes/tests/open_nodes_test.py
+++ b/gateway_code/open_nodes/tests/open_nodes_test.py
@@ -30,6 +30,7 @@ from gateway_code.nodes import (open_node_class, control_node_class,
                                 OpenNodeBase, ControlNodeBase)
 from gateway_code.open_nodes.node_a8 import NodeA8
 from gateway_code.open_nodes.node_m3 import NodeM3
+from gateway_code.config import static_path
 
 
 def test_node_class():
@@ -215,3 +216,35 @@ def test_open_node_inheritance():
     assert board_instance.setup('path/to/firmware') == 42
     assert board_instance.teardown() == 4242
     assert board_instance.status() == 0
+
+
+def test_open_node_verify():
+    """
+        test case for verify open node method
+    """
+
+    class BaseOpenNode(OpenNodeBase):
+        # pylint:disable=abstract-method
+        """Basic empty OpenNode"""
+        TYPE = "base_open_node"
+        ELF_TARGET = ('ELFCLASS32', 'EM_ARM')
+        AUTOTEST_AVAILABLE = ['echo', 'get_time']
+        FW_IDLE = static_path('m3_idle.elf')
+        FW_AUTOTEST = static_path('m3_autotest.elf')
+
+        def setup(self, firmware_path):
+            """ Setup the open node with a firmware"""
+            return 0
+
+        def teardown(self):
+            """ Cleanup the open node """
+            return 0
+
+        def status(self):
+            """ Status of the node """
+            return 0
+
+    board = open_node_class("base_open_node")
+    assert board == BaseOpenNode
+    board_instance = board()
+    assert board_instance.verify() == 0

--- a/gateway_code/open_nodes/tests/open_nodes_test.py
+++ b/gateway_code/open_nodes/tests/open_nodes_test.py
@@ -79,6 +79,22 @@ def test_registry_open_node():
         ELF_TARGET = ('ELFCLASS32', 'EM_ARM')
         AUTOTEST_AVAILABLE = ['echo', 'get_time']
 
+        def setup(self, firmware_path):
+            """ Setup the open node with a firmware"""
+            return 0
+
+        def teardown(self):
+            """ Cleanup the open node """
+            return 0
+
+        def status(self):
+            """ Status of the node """
+            return 0
+
+        def verify(self):
+            """ Verify the open node """
+            return 0
+
     assert open_node_class("my_node") == MyNode
 
     with pytest.raises(ValueError):
@@ -110,6 +126,22 @@ def test_registry_inheritance():
         TYPE = "base_open_node"
         ELF_TARGET = ('ELFCLASS32', 'EM_ARM')
         AUTOTEST_AVAILABLE = ['echo', 'get_time']
+
+        def setup(self, firmware_path):
+            """ Setup the open node with a firmware"""
+            return 0
+
+        def teardown(self):
+            """ Cleanup the open node """
+            return 0
+
+        def status(self):
+            """ Status of the node """
+            return 0
+
+        def verify(self):
+            """ Verify the open node """
+            return 0
 
     class DerivedOpenNode(BaseOpenNode):
         # pylint:disable=abstract-method


### PR DESCRIPTION
This PR is a preleminary work to integrate RPI3 Open Linux node. Indeed we add verify method in the OpenNodeBase class instead of a global method which verify when you load open nodes class from the registry.
It provides to override this method in open nodes class (ex: NodeA8) and adapt the verification. Thus in Linux open nodes class we won't check attributes like available autotests or firmware target (e.g. ELF_TARGET)
