### PR TITLE
open_nodes: introduce node with no programmable node and rtl_sdr node

### DIFF
--- a/gateway_code/open_nodes/common/node_no.py
+++ b/gateway_code/open_nodes/common/node_no.py
@@ -22,7 +22,6 @@
 """ Experiment implementation of an open node that has no node."""
 import logging
 
-from gateway_code import common
 from gateway_code.common import logger_call
 from gateway_code.nodes import OpenNodeBase
 
@@ -35,26 +34,28 @@ class NodeNoBase(OpenNodeBase):
 
     @logger_call("Node No: Setup of no node")
     def setup(self, firmware_path=None):
+        # pylint:disable=unused-argument,no-self-use
         """.Does nothing."""
         return 0
 
     @logger_call("Node No: teardown of no node")
-    def teardown(self):
+    def teardown(self):  # pylint:disable=no-self-use
         """.Does nothing."""
         return 0
 
     @logger_call("Node No: flash of no node")
     def flash(self, firmware_path=None):
+        # pylint:disable=unused-argument,no-self-use
         """Does nothing."""
         return 0
 
     @logger_call("Node No: reset of no node")
-    def reset(self):
+    def reset(self):  # pylint:disable=no-self-use
         """Does nothing."""
         return 0
 
     @staticmethod
-    def status():
+    def status():  # pylint:disable=no-self-use
         """Does nothing."""
         return 0
 

--- a/gateway_code/open_nodes/common/node_no.py
+++ b/gateway_code/open_nodes/common/node_no.py
@@ -1,0 +1,64 @@
+# -*- coding:utf-8 -*-
+
+# This file is a part of IoT-LAB gateway_code
+# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Contributor(s) : see AUTHORS file
+#
+# This software is governed by the CeCILL license under French law
+# and abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# http://www.cecill.info.
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+
+""" Experiment implementation of an open node that has no node."""
+import logging
+
+from gateway_code import common
+from gateway_code.common import logger_call
+from gateway_code.nodes import OpenNodeBase
+
+LOGGER = logging.getLogger('gateway_code')
+
+
+class NodeNoBase(OpenNodeBase):
+    # pylint:disable=no-member
+    """Open node No implementation."""
+
+    @logger_call("Node No: Setup of no node")
+    def setup(self, firmware_path):
+        """.Does nothing."""
+        return 0
+
+    @logger_call("Node No: teardown of no node")
+    def teardown(self):
+        """.Does nothing."""
+        return 0
+
+    @logger_call("Node No: flash of no node")
+    def flash(self, firmware_path=None):
+        """Does nothing."""
+        return 0
+
+    @logger_call("Node No: reset of no node")
+    def reset(self):
+        """Does nothing."""
+        return 0
+
+    @staticmethod
+    def status():
+        """Does nothing."""
+        return 0
+
+    @classmethod
+    def verify(cls):  # pylint:disable=unused-argument
+        """This class is always valid."""
+        return 0

--- a/gateway_code/open_nodes/common/node_no.py
+++ b/gateway_code/open_nodes/common/node_no.py
@@ -34,7 +34,7 @@ class NodeNoBase(OpenNodeBase):
     """Open node No implementation."""
 
     @logger_call("Node No: Setup of no node")
-    def setup(self, firmware_path):
+    def setup(self, firmware_path=None):
         """.Does nothing."""
         return 0
 

--- a/gateway_code/open_nodes/common/tests/node_no_test.py
+++ b/gateway_code/open_nodes/common/tests/node_no_test.py
@@ -1,0 +1,36 @@
+# -*- coding:utf-8 -*-
+
+# This file is a part of IoT-LAB gateway_code
+# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Contributor(s) : see AUTHORS file
+#
+# This software is governed by the CeCILL license under French law
+# and abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# http://www.cecill.info.
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+
+""" gateway_code.open_nodes.common.node_no unit tests file """
+
+
+from gateway_code.open_nodes.common.node_no import NodeNoBase
+
+
+def test_node_no():
+    node = NodeNoBase()
+
+    assert node.setup() == 0
+    assert node.teardown() == 0
+    assert node.flash() == 0
+    assert node.reset() == 0
+    assert node.status() == 0
+    assert node.verify() == 0

--- a/gateway_code/open_nodes/common/tests/node_no_test.py
+++ b/gateway_code/open_nodes/common/tests/node_no_test.py
@@ -26,8 +26,8 @@ from gateway_code.open_nodes.common.node_no import NodeNoBase
 
 
 def test_node_no():
+    """Basic unittesting for node_no."""
     node = NodeNoBase()
-
     assert node.setup() == 0
     assert node.teardown() == 0
     assert node.flash() == 0

--- a/gateway_code/open_nodes/node_rtl_sdr.py
+++ b/gateway_code/open_nodes/node_rtl_sdr.py
@@ -25,8 +25,6 @@ import logging
 import shlex
 import subprocess
 
-import gateway_code.utils.ftdi_check
-
 from gateway_code.common import logger_call
 from gateway_code.utils.rtl_tcp import RtlTcp
 from gateway_code.open_nodes.common.node_no import NodeNoBase

--- a/gateway_code/open_nodes/node_rtl_sdr.py
+++ b/gateway_code/open_nodes/node_rtl_sdr.py
@@ -1,0 +1,65 @@
+# -*- coding:utf-8 -*-
+
+# This file is a part of IoT-LAB gateway_code
+# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Contributor(s) : see AUTHORS file
+#
+# This software is governed by the CeCILL license under French law
+# and abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# http://www.cecill.info.
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+
+""" Open Node Rtl SDR experiment implementation """
+
+import logging
+import shlex
+import subprocess
+
+import gateway_code.utils.ftdi_check
+
+from gateway_code.common import logger_call
+from gateway_code.utils.rtl_tcp import RtlTcp
+from gateway_code.open_nodes.common.node_no import NodeNoBase
+
+LOGGER = logging.getLogger('gateway_code')
+
+# This command controls the power of the open node/rtl_tcp USB stick via the
+# Yepkit module.
+YKUSHCMD = "sudo ykushcmd {model} {cmd} {port}"
+
+
+class NodeRtlSdr(NodeNoBase):
+    """ Open node Rtl SDR implementation """
+
+    TYPE = 'rtl_sdr'
+    RTL_TCP_PORT = 50000
+    RTL_TCP_FREQ = 868000000
+
+    def __init__(self):
+        self.rtl_tcp = RtlTcp(self.RTL_TCP_PORT, self.RTL_TCP_FREQ)
+
+    @logger_call("Node No: Setup of no node")
+    def setup(self, firmware_path=None):
+        """Power up the SDR dongle and start rtl_tcp server."""
+        ykushcmd_str = YKUSHCMD.format(model="", cmd="-u", port="3")
+        ret_val = subprocess.call(shlex.split(ykushcmd_str))
+        ret_val += self.rtl_tcp.start()
+        return ret_val
+
+    @logger_call("Node No: teardown of no node")
+    def teardown(self):
+        """Stop rtl_tcp server and poweroff the SDR dongle."""
+        ret_val = self.rtl_tcp.stop()
+        ykushcmd_str = YKUSHCMD.format(model="", cmd="-d", port="3")
+        ret_val += subprocess.call(shlex.split(ykushcmd_str))
+        return ret_val

--- a/gateway_code/open_nodes/tests/node_rtl_sdr_test.py
+++ b/gateway_code/open_nodes/tests/node_rtl_sdr_test.py
@@ -1,0 +1,75 @@
+# -*- coding:utf-8 -*-
+
+# This file is a part of IoT-LAB gateway_code
+# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Contributor(s) : see AUTHORS file
+#
+# This software is governed by the CeCILL license under French law
+# and abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# http://www.cecill.info.
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+
+""" gateway_code.open_nodes.node_rtl_sdr unit tests files """
+
+import shlex
+from mock import patch
+
+from gateway_code.open_nodes.node_rtl_sdr import NodeRtlSdr, YKUSHCMD
+
+
+@patch('subprocess.call')
+@patch('gateway_code.utils.external_process.ExternalProcess.start')
+def test_setup(rtl_tcp_start, call):
+    """Test rtl_sdr node setup."""
+    call.return_value = 0
+    rtl_tcp_start.return_value = 0
+    ykushcmd = YKUSHCMD.format(model="", cmd="-u", port="3")
+    node = NodeRtlSdr()
+
+    assert node.setup() == 0
+    assert call.call_count == 1
+    assert rtl_tcp_start.call_count == 1
+    call.assert_called_with(shlex.split(ykushcmd))
+
+    call.call_count = 0
+    rtl_tcp_start.call_count = 0
+
+    call.return_value = 1
+    assert node.setup() == 1
+    assert call.call_count == 1
+    assert rtl_tcp_start.call_count == 1
+    call.assert_called_with(shlex.split(ykushcmd))
+
+
+@patch('subprocess.call')
+@patch('gateway_code.utils.external_process.ExternalProcess.stop')
+def test_teardown(rtl_tcp_stop, call):
+    """Test rtl_sdr node teardown."""
+    call.return_value = 0
+    rtl_tcp_stop.return_value = 0
+    ykushcmd = YKUSHCMD.format(model="", cmd="-d", port="3")
+
+    node = NodeRtlSdr()
+    assert node.teardown() == 0
+    assert call.call_count == 1
+    assert rtl_tcp_stop.call_count == 1
+    call.assert_called_with(shlex.split(ykushcmd))
+
+    call.call_count = 0
+    rtl_tcp_stop.call_count = 0
+
+    call.return_value = 1
+    assert node.teardown() == 1
+    assert call.call_count == 1
+    assert rtl_tcp_stop.call_count == 1
+    call.assert_called_with(shlex.split(ykushcmd))


### PR DESCRIPTION
This PR adds the support of the RTL-SDR dongle as a regular open node.
- this node provides no programmable node => it was necessary to have a base open node with no node
- this node manage the RTL-SDR power and rtl_tcp daemon. The power of the dongle is controlled via a YepKit module (default model with 3 USB ports, the dongle must be plugged on port 3).

This code can be tested on devsaclay.