### PR TITLE
tests: fix assertEquals/assertNotEquals deprecated-method error with pylint

### DIFF
--- a/gateway_code/autotest/tests/autotest_test.py
+++ b/gateway_code/autotest/tests/autotest_test.py
@@ -52,8 +52,8 @@ class TestProtocol(unittest.TestCase):
         ret_1 = self.g_v._check(0, 'message_1', ['1', '2'])
         ret_2 = self.g_v._check(1, 'message_2', ['3', '4'])
 
-        self.assertEquals(0, ret_1)
-        self.assertEquals(1, ret_2)
+        self.assertEqual(0, ret_1)
+        self.assertEqual(1, ret_2)
 
         self.assertTrue('message_1' in self.g_v.ret_dict['success'])
         self.assertTrue('message_2' in self.g_v.ret_dict['error'])
@@ -71,7 +71,7 @@ class TestProtocol(unittest.TestCase):
 
         values = self.g_v._run_test(3, ['test_command'], lambda x: float(x[2]))
 
-        self.assertEquals([3.14], values)
+        self.assertEqual([3.14], values)
         mock_error.assert_called_with('Autotest: %r: %r',
                                       "On Command: ['test_command']",
                                       ['NACK', 'test_command', '1.414'])
@@ -81,13 +81,13 @@ class TestProtocol(unittest.TestCase):
         """ Test get_uid autotest function """
 
         run_test_mock.return_value = ['05D8FF323632483343037109']
-        self.assertEquals(0, self.g_v.get_uid())
-        self.assertEquals('05D8:FF32:3632:4833:4303:7109',
-                          self.g_v.ret_dict['open_node_uid'])
+        self.assertEqual(0, self.g_v.get_uid())
+        self.assertEqual('05D8:FF32:3632:4833:4303:7109',
+                         self.g_v.ret_dict['open_node_uid'])
 
         # error on get_uid
         run_test_mock.return_value = []
-        self.assertNotEquals(0, self.g_v.get_uid())
+        self.assertNotEqual(0, self.g_v.get_uid())
 
 
 class TestProtocolGPS(unittest.TestCase):
@@ -103,12 +103,12 @@ class TestProtocolGPS(unittest.TestCase):
     def test_test_gps(self):
         with mock.patch.object(self.g_v, '_test_pps_open_node') as test_pps:
             # test with gps disabled
-            self.assertEquals(0, self.g_v.test_gps(False))
+            self.assertEqual(0, self.g_v.test_gps(False))
             self.assertFalse(test_pps.called)
 
             # Test with gps enabled
             test_pps.return_value = 0
-            self.assertEquals(0, self.g_v.test_gps(True))
+            self.assertEqual(0, self.g_v.test_gps(True))
             self.assertTrue(test_pps.called)
 
     def test__test_pps_open_node(self):
@@ -128,10 +128,10 @@ class TestProtocolGPS(unittest.TestCase):
         with mock.patch.object(self.g_v, '_on_call', _on_call):
             pps_get_values = [(0, ['ACK', 'test_pps_get', '0', 'pps']),
                               (0, ['ACK', 'test_pps_get', '3', 'pps'])]
-            self.assertEquals(0, self.g_v._test_pps_open_node(10))
+            self.assertEqual(0, self.g_v._test_pps_open_node(10))
 
             pps_get_values = []
-            self.assertNotEquals(0, self.g_v._test_pps_open_node(0))
+            self.assertNotEqual(0, self.g_v._test_pps_open_node(0))
 
             with pytest.raises(ValueError) as exc:
                 self.g_v._test_pps_open_node_invalid()
@@ -213,8 +213,8 @@ class TestAutoTestsErrorCases(unittest.TestCase):
         ret_dict = self.g_v.auto_tests()
 
         self.assertTrue(ret_dict['ret'] >= 2)
-        self.assertEquals([], ret_dict['success'])
-        self.assertEquals(['setup', 'teardown'], ret_dict['error'])
+        self.assertEqual([], ret_dict['success'])
+        self.assertEqual(['setup', 'teardown'], ret_dict['error'])
 
     @mock.patch('gateway_code.autotest.autotest.AutoTestManager.'
                 '_set_results_leds')
@@ -236,4 +236,4 @@ class TestAutotestFatalError(unittest.TestCase):
 
     def test_fatal_error(self):
         error = autotest.FatalError("error_value")
-        self.assertEquals("'error_value'", str(error))
+        self.assertEqual("'error_value'", str(error))

--- a/gateway_code/autotest/tests/open_a8_interface_test.py
+++ b/gateway_code/autotest/tests/open_a8_interface_test.py
@@ -38,10 +38,10 @@ from gateway_code.autotest import open_a8_interface
 class TestA8Connection(unittest.TestCase):
     def test_connection_error(self):
         error = open_a8_interface.A8ConnectionError("value", "err_msg")
-        self.assertEquals("'value' : 'err_msg'", str(error))
+        self.assertEqual("'value' : 'err_msg'", str(error))
 
     @mock.patch('gateway_code.autotest.open_a8_interface.OpenA8Connection.scp')
     def test_flash_error(self, scp):
         scp.side_effect = CalledProcessError(1, 'flash', 'flash failed')
         connection = open_a8_interface.OpenA8Connection()
-        self.assertEquals(connection.flash('test/firmware'), 1)
+        self.assertEqual(connection.flash('test/firmware'), 1)

--- a/gateway_code/control_nodes/cn_iotlab/tests/cn_interface_test.py
+++ b/gateway_code/control_nodes/cn_iotlab/tests/cn_interface_test.py
@@ -65,7 +65,7 @@ class TestControlNodeSerial(unittest.TestCase):
 
     def test_normal_start_stop(self):
         ret_start = self.cn.start()
-        self.assertEquals(0, ret_start)
+        self.assertEqual(0, ret_start)
         self.assertTrue(self.popen.stderr.readline.called)
 
         self.cn.stop()
@@ -78,7 +78,7 @@ class TestControlNodeSerial(unittest.TestCase):
         self.popen.poll.return_value = 2
 
         ret_start = self.cn.start()
-        self.assertNotEquals(0, ret_start)
+        self.assertNotEqual(0, ret_start)
         self.log_error.check(
             ('gateway_code', 'ERROR',
              'Control node serial reader thread ended prematurely'))
@@ -98,7 +98,7 @@ class TestControlNodeSerial(unittest.TestCase):
 
         # try sending command
         ret = self.cn.send_command(['test', 'cmd'])
-        self.assertEquals(None, ret)
+        self.assertEqual(None, ret)
         self.log_error.check(
             ('gateway_code', 'ERROR',
              'control_node_serial process is terminated'))
@@ -133,7 +133,7 @@ class TestControlNodeSerial(unittest.TestCase):
 
         self.cn.start()
         ret = self.cn.send_command(['start', 'DC'])
-        self.assertEquals(['start', 'ACK'], ret)
+        self.assertEqual(['start', 'ACK'], ret)
         self.cn.stop()
 
     def test_send_command_no_answer(self):

--- a/gateway_code/control_nodes/cn_iotlab/tests/cn_protocol_test.py
+++ b/gateway_code/control_nodes/cn_iotlab/tests/cn_protocol_test.py
@@ -54,7 +54,7 @@ class TestProtocol(unittest.TestCase):
                                           voltage=True,
                                           current=True)
         ret = self.protocol.config_consumption(consumption)
-        self.assertEquals(0, ret)
+        self.assertEqual(0, ret)
         self.sender.assert_called_with(['config_consumption_measure', 'start',
                                         '3.3V', 'p', '1', 'v', '1', 'c', '1',
                                         '-p', '140', '-a', '1'])
@@ -66,7 +66,7 @@ class TestProtocol(unittest.TestCase):
                                           average=1024,
                                           power=True)
         ret = self.protocol.config_consumption(consumption)
-        self.assertEquals(0, ret)
+        self.assertEqual(0, ret)
         self.sender.assert_called_with(['config_consumption_measure', 'start',
                                         'BATT', 'p', '1', 'v', '0', 'c', '0',
                                         '-p', '8244', '-a', '1024'])
@@ -77,7 +77,7 @@ class TestProtocol(unittest.TestCase):
         # no consumption object
         ret = self.protocol.config_consumption()
         self.sender.assert_called_with(['config_consumption_measure', 'stop'])
-        self.assertEquals(0, ret)
+        self.assertEqual(0, ret)
         # power, voltage, current == False
         consumption = profile.Consumption(alim='3.3V',
                                           source='dc',
@@ -85,7 +85,7 @@ class TestProtocol(unittest.TestCase):
                                           average=1)
         ret = self.protocol.config_consumption(consumption)
         self.sender.assert_called_with(['config_consumption_measure', 'stop'])
-        self.assertEquals(0, ret)
+        self.assertEqual(0, ret)
 
     def test_start_stop(self):
 
@@ -93,42 +93,42 @@ class TestProtocol(unittest.TestCase):
 
         ret = self.protocol.start_stop('start', 'dc')
         self.sender.assert_called_with(['start', 'dc'])
-        self.assertEquals(0, ret)
+        self.assertEqual(0, ret)
 
         # return NACK
         self.sender.return_value = ['start', 'ACK']
         ret = self.protocol.start_stop('stop', 'dc')
         self.sender.assert_called_with(['stop', 'dc'])
-        self.assertEquals(1, ret)
+        self.assertEqual(1, ret)
 
         # return command different type
         self.sender.return_value = ['stop', 'NACK']
         ret = self.protocol.start_stop('stop', 'battery')
         self.sender.assert_called_with(['stop', 'battery'])
-        self.assertEquals(1, ret)
+        self.assertEqual(1, ret)
 
     def test_set_time(self):
 
         self.sender.return_value = ['set_time', 'ACK']
         ret = self.protocol.set_time()
         self.sender.assert_called_with(['set_time'])
-        self.assertEquals(0, ret)
+        self.assertEqual(0, ret)
 
         self.sender.return_value = ['set_time', 'NACK']
         ret = self.protocol.set_time()
         self.sender.assert_called_with(['set_time'])
-        self.assertEquals(1, ret)
+        self.assertEqual(1, ret)
 
     def test_set_node_id(self):
         self.sender.return_value = ['set_node_id', 'ACK']
         ret = self.protocol.set_node_id('m3-1')
         self.sender.assert_called_with(['set_node_id', 'm3', '1'])
-        self.assertEquals(0, ret)
+        self.assertEqual(0, ret)
 
         self.sender.return_value = ['set_node_id', 'ACK']
         ret = self.protocol.set_node_id('a8-256')
         self.sender.assert_called_with(['set_node_id', 'a8', '256'])
-        self.assertEquals(0, ret)
+        self.assertEqual(0, ret)
 
         self.sender.call_count = 0
         ret = self.protocol.set_node_id('leonardo-256')
@@ -140,12 +140,12 @@ class TestProtocol(unittest.TestCase):
         self.sender.return_value = ['green_led_blink', 'ACK']
         ret = self.protocol.green_led_blink()
         self.sender.assert_called_with(['green_led_blink'])
-        self.assertEquals(0, ret)
+        self.assertEqual(0, ret)
 
         self.sender.return_value = ['green_led_on', 'ACK']
         ret = self.protocol.green_led_on()
         self.sender.assert_called_with(['green_led_on'])
-        self.assertEquals(0, ret)
+        self.assertEqual(0, ret)
 
 
 class TestProtocolRadio(unittest.TestCase):
@@ -167,9 +167,9 @@ class TestProtocolRadio(unittest.TestCase):
         self.protocol._stop_radio.return_value = 0
 
         ret = self.protocol.config_radio(radio)
-        self.assertEquals(0, ret)
-        self.assertEquals(0, self.protocol._stop_radio.call_count)
-        self.assertEquals(1, self.protocol._config_radio_measure.call_count)
+        self.assertEqual(0, ret)
+        self.assertEqual(0, self.protocol._stop_radio.call_count)
+        self.assertEqual(1, self.protocol._config_radio_measure.call_count)
 
     def test_config_radio_with_sniffer(self):
         """ Configure Radio with 'measure' mode """
@@ -181,9 +181,9 @@ class TestProtocolRadio(unittest.TestCase):
         self.protocol._stop_radio.return_value = 0
 
         ret = self.protocol.config_radio(radio)
-        self.assertEquals(0, ret)
-        self.assertEquals(0, self.protocol._stop_radio.call_count)
-        self.assertEquals(1, self.protocol._config_radio_sniffer.call_count)
+        self.assertEqual(0, ret)
+        self.assertEqual(0, self.protocol._stop_radio.call_count)
+        self.assertEqual(1, self.protocol._config_radio_sniffer.call_count)
 
     def test_config_radio_with_none(self):
         """ Configure radio with None Radio profile """
@@ -194,8 +194,8 @@ class TestProtocolRadio(unittest.TestCase):
         self.protocol._stop_radio.return_value = 0
 
         self.protocol.config_radio(None)
-        self.assertEquals(0, self.protocol._config_radio_measure.call_count)
-        self.assertEquals(1, self.protocol._stop_radio.call_count)
+        self.assertEqual(0, self.protocol._config_radio_measure.call_count)
+        self.assertEqual(1, self.protocol._stop_radio.call_count)
 
     def test_config_radio_with_invalid_mode(self):
         """ Configure radio with an non supported radio mode """
@@ -216,9 +216,9 @@ class TestProtocolRadio(unittest.TestCase):
 
         ret = self.protocol.config_radio(radio)
 
-        self.assertEquals(0xFF, ret)
-        self.assertEquals(0, self.protocol._stop_radio.call_count)
-        self.assertEquals(1, self.protocol._config_radio_measure.call_count)
+        self.assertEqual(0xFF, ret)
+        self.assertEqual(0, self.protocol._stop_radio.call_count)
+        self.assertEqual(1, self.protocol._config_radio_measure.call_count)
 
     def test_config_radio_measure(self):
 
@@ -228,7 +228,7 @@ class TestProtocolRadio(unittest.TestCase):
         ret = self.protocol._config_radio_measure(radio)
         self.sender.assert_called_with(['config_radio_measure', '11,15,17',
                                         '100', '10'])
-        self.assertEquals(0, ret)
+        self.assertEqual(0, ret)
 
     def test_config_radio_sniffer(self):
         radio = profile.Radio("sniffer", [17, 15, 11], 100)
@@ -237,7 +237,7 @@ class TestProtocolRadio(unittest.TestCase):
         ret = self.protocol._config_radio_sniffer(radio)
         self.sender.assert_called_with(['config_radio_sniffer', '11,15,17',
                                         '100'])
-        self.assertEquals(0, ret)
+        self.assertEqual(0, ret)
 
     def test__stop_radio(self):
 
@@ -246,4 +246,4 @@ class TestProtocolRadio(unittest.TestCase):
         ret = self.protocol._stop_radio()
 
         self.sender.assert_called_with(['config_radio_stop'])
-        self.assertEquals(0, ret)
+        self.assertEqual(0, ret)

--- a/gateway_code/integration/autotest_test.py
+++ b/gateway_code/integration/autotest_test.py
@@ -47,10 +47,10 @@ class TestAutoTests(test_integration_mock.GatewayCodeMock):
         ret_dict = ret.json
         print >> sys.stderr, ret_dict
 
-        self.assertEquals([], ret_dict['error'])
+        self.assertEqual([], ret_dict['error'])
         self.assertIn('on_serial_echo', ret_dict['success'])
         self.assertTrue('GWT' in ret_dict['mac'])
-        self.assertEquals(0, ret_dict['ret'])
+        self.assertEqual(0, ret_dict['ret'])
 
         # test that ON still on
         if self.board_cfg.board_type == 'a8':
@@ -64,15 +64,15 @@ class TestAutoTests(test_integration_mock.GatewayCodeMock):
 
         not_tested = (set(self.g_m.open_node.AUTOTEST_AVAILABLE) -
                       set(AutoTestManager.TESTED_FEATURES))
-        self.assertEquals(not_tested, set())
+        self.assertEqual(not_tested, set())
 
     def test_mode_no_blink_no_radio(self):
         """ Try running autotest without blinking leds and without radio """
         ret = self.server.put('/autotest')
         ret_dict = ret.json
 
-        self.assertEquals([], ret_dict['error'])
-        self.assertEquals(0, ret_dict['ret'])
+        self.assertEqual([], ret_dict['error'])
+        self.assertEqual(0, ret_dict['ret'])
         # Radio functions not in results
         self.assertNotIn('test_radio_ping_pong', ret_dict['success'])
         self.assertNotIn('rssi_measures', ret_dict['success'])

--- a/gateway_code/integration/integration_test.py
+++ b/gateway_code/integration/integration_test.py
@@ -117,12 +117,12 @@ class TestComplexExperimentRunning(ExperimentRunningMock):
     def _run_simple_experiment_a8(self):  # pylint:disable=unused-argument
         """ Run an experiment for a8 nodes """
 
-        self.assertEquals(0, self.server.post(EXP_START).json['ret'])
+        self.assertEqual(0, self.server.post(EXP_START).json['ret'])
 
         # waiting One minute to try to have complete boot log on debug output
         time.sleep(60)  # maybe do something here later
 
-        self.assertEquals(0, self.server.delete('/exp/stop').json['ret'])
+        self.assertEqual(0, self.server.delete('/exp/stop').json['ret'])
 
     def _run_simple_experiment_node(self, board_class):
         """
@@ -132,7 +132,7 @@ class TestComplexExperimentRunning(ExperimentRunningMock):
         # start exp with idle firmware
         files = [file_tuple('firmware', board_class.FW_IDLE)]
         ret = self.server.post(EXP_START, upload_files=files)
-        self.assertEquals(0, ret.json['ret'])
+        self.assertEqual(0, ret.json['ret'])
 
         # wait firmware started
         time.sleep(1)
@@ -142,16 +142,16 @@ class TestComplexExperimentRunning(ExperimentRunningMock):
 
         # flash echo firmware
         ret = self._flash(board_class.FW_AUTOTEST)
-        self.assertEquals(0, ret.json['ret'])
+        self.assertEqual(0, ret.json['ret'])
 
         # Should echo <message>
         self._check_node_echo(echo=True)
 
         # open node reset and start stop
-        self.assertEquals(0, self.server.put('/open/reset').json['ret'])
+        self.assertEqual(0, self.server.put('/open/reset').json['ret'])
         if self.control_node_has('open_node_power'):
-            self.assertEquals(0, self.server.put('/open/stop').json['ret'])
-            self.assertEquals(0, self.server.put('/open/start').json['ret'])
+            self.assertEqual(0, self.server.put('/open/stop').json['ret'])
+            self.assertEqual(0, self.server.put('/open/start').json['ret'])
 
         # It is normal to fail if you flash just after starting a node
         # In these tests, I want the node to be "ready" so I ensure that
@@ -174,9 +174,9 @@ class TestComplexExperimentRunning(ExperimentRunningMock):
 
         if self.control_node_has('open_node_power'):
             # Stop should work with stopped node
-            self.assertEquals(0, self.server.put('/open/stop').json['ret'])
+            self.assertEqual(0, self.server.put('/open/stop').json['ret'])
         # stop exp
-        self.assertEquals(0, self.server.delete('/exp/stop').json['ret'])
+        self.assertEqual(0, self.server.delete('/exp/stop').json['ret'])
 
         # Got no error during tests (use call_args_list for printing on error)
         self.log_error.check()
@@ -228,18 +228,18 @@ class TestComplexExperimentRunning(ExperimentRunningMock):
 
         # Flash idle firmware
         ret = self._flash()
-        self.assertEquals(0, ret.json['ret'])
+        self.assertEqual(0, ret.json['ret'])
 
         # idle firmware, there should be no reply
         self._check_node_echo(echo=False)
 
         # Start debugger
         ret = self.server.put('/open/debug/start')
-        self.assertEquals(0, ret.json['ret'])
+        self.assertEqual(0, ret.json['ret'])
 
         # Flash autotest firmware
         ret = subprocess.call(gdb_cmd, stderr=subprocess.STDOUT)
-        self.assertEquals(0, ret)
+        self.assertEqual(0, ret)
         time.sleep(1)
 
         # Autotest fw should be running
@@ -247,19 +247,19 @@ class TestComplexExperimentRunning(ExperimentRunningMock):
 
         # Flash idle firmware should fail
         ret = self._flash()
-        self.assertNotEquals(0, ret.json['ret'])
+        self.assertNotEqual(0, ret.json['ret'])
 
         # No flash, Autotest fw should be still running
         self._check_node_echo(echo=True)
 
         # Stop debugger
         ret = self.server.put('/open/debug/stop')
-        self.assertEquals(0, ret.json['ret'])
+        self.assertEqual(0, ret.json['ret'])
 
         # Make sure the node can be reflashed after debug session is done
         time.sleep(1)
         ret = self._flash()
-        self.assertEquals(0, ret.json['ret'])
+        self.assertEqual(0, ret.json['ret'])
 
     def test_m3_exp_invalid_fw_target(self):
         """Run an experiment with an invalid firmware."""
@@ -276,11 +276,11 @@ class TestComplexExperimentRunning(ExperimentRunningMock):
             ret = self.server.post(EXP_START, upload_files=files)
 
             # Error and flash not called
-            self.assertNotEquals(0, ret.json['ret'])
+            self.assertNotEqual(0, ret.json['ret'])
             self.assertFalse(flash_mock.called)
 
         ret = self.server.delete('/exp/stop')
-        self.assertEquals(0, ret.json['ret'])
+        self.assertEqual(0, ret.json['ret'])
 
     def test_m3_flash_inval_fw(self):
         """Flash an invalid firmware during an experiment."""
@@ -288,7 +288,7 @@ class TestComplexExperimentRunning(ExperimentRunningMock):
             pytest.skip("Not an M3")
 
         ret = self.server.post(EXP_START)
-        self.assertEquals(0, ret.json['ret'])
+        self.assertEqual(0, ret.json['ret'])
 
         # Invalid firmware for m3
         node_z1 = CURRENT_DIR + 'node.z1'
@@ -296,11 +296,11 @@ class TestComplexExperimentRunning(ExperimentRunningMock):
             flash_mock.return_value = 0
             ret = self._flash(node_z1)
             # Error and flash not called
-            self.assertNotEquals(0, ret.json['ret'])
+            self.assertNotEqual(0, ret.json['ret'])
             self.assertFalse(flash_mock.called)
 
         ret = self.server.delete('/exp/stop')
-        self.assertEquals(0, ret.json['ret'])
+        self.assertEqual(0, ret.json['ret'])
 
     def _update_profile(self, profilefilename=None, assert_ret=True):
         """Update profile with given 'profilename' file."""
@@ -311,7 +311,7 @@ class TestComplexExperimentRunning(ExperimentRunningMock):
 
         ret = self.server.post('/exp/update', profile, content_type=APP_JSON)
         if assert_ret:
-            self.assertEquals(0, ret.json['ret'])
+            self.assertEqual(0, ret.json['ret'])
         return ret
 
     def test_m3_exp_with_measures(self):  # pylint:disable=too-many-locals
@@ -330,7 +330,7 @@ class TestComplexExperimentRunning(ExperimentRunningMock):
             file_tuple('firmware', self.board_cfg.board_class.FW_AUTOTEST),
         ]
         ret = self.server.post(EXP_START, upload_files=files)
-        self.assertEquals(0, ret.json['ret'])
+        self.assertEqual(0, ret.json['ret'])
 
         # Copy files for further checking
         exp_files = self.g_m.exp_files.copy()
@@ -349,15 +349,15 @@ class TestComplexExperimentRunning(ExperimentRunningMock):
         # # # # # # # # # #
 
         # Got consumption and radio
-        self.assertNotEquals([], measures['consumption']['values'])
-        self.assertNotEquals([], measures['radio']['values'])
+        self.assertNotEqual([], measures['consumption']['values'])
+        self.assertNotEqual([], measures['radio']['values'])
 
         # Validate values
         for values in measures['consumption']['values']:
             # no power, voltage in 3.3V, current not null
             self.assertTrue(math.isnan(values[0]))
             self.assertTrue(2.8 <= values[1] <= 3.5)
-            self.assertNotEquals(0.0, values[2])
+            self.assertNotEqual(0.0, values[2])
         for values in measures['radio']['values']:
             self.assertIn(values[0], [15, 26])
             self.assertLessEqual(-91, values[1])
@@ -372,10 +372,10 @@ class TestComplexExperimentRunning(ExperimentRunningMock):
         # wait 5 more seconds that no measures arrive
         # wait_cond is used as 'check still false'
         wait_cond(5, False, lambda: [] == self.cn_measures)
-        self.assertEquals([], self.cn_measures)
+        self.assertEqual([], self.cn_measures)
 
         # Stop experiment
-        self.assertEquals(0, self.server.delete('/exp/stop').json['ret'])
+        self.assertEqual(0, self.server.delete('/exp/stop').json['ret'])
         # Got no error during tests (use assertEquals for printing result)
         self.log_error.check()
 
@@ -405,7 +405,7 @@ class TestComplexExperimentRunning(ExperimentRunningMock):
 
         # Start
         ret = self.server.post(EXP_START, upload_files=files)
-        self.assertEquals(0, ret.json['ret'])
+        self.assertEqual(0, ret.json['ret'])
         # Copy files for further checking
         exp_files = self.g_m.exp_files.copy()
 
@@ -427,7 +427,7 @@ class TestComplexExperimentRunning(ExperimentRunningMock):
         time.sleep(2)  # wait maybe remaining values
 
         # Stop experiment
-        self.assertEquals(0, self.server.delete('/exp/stop').json['ret'])
+        self.assertEqual(0, self.server.delete('/exp/stop').json['ret'])
 
         # Got no error during tests (use assertEquals for printing result)
         if self.board_cfg.board_class.TYPE != 'a8':
@@ -478,7 +478,7 @@ class TestExperimentTimeout(ExperimentRunningMock):
         """ Start an experiment with a timeout. """
         extra = query_string('timeout=5')
         ret = self.server.post(EXP_START, extra_environ=extra)
-        self.assertEquals(0, ret.json['ret'])
+        self.assertEqual(0, ret.json['ret'])
 
         # Wait max 10 seconds for experiment to have been stopped
         self.assertTrue(wait_cond(10, False, self._safe_exp_is_running))
@@ -488,9 +488,9 @@ class TestExperimentTimeout(ExperimentRunningMock):
         """ Test exp_stop removes timeout stop """
         extra = query_string('timeout=5')
         ret = self.server.post(EXP_START, extra_environ=extra)
-        self.assertEquals(0, ret.json['ret'])
+        self.assertEqual(0, ret.json['ret'])
         # Stop to remove timeout
-        self.assertEquals(0, self.server.delete('/exp/stop').json['ret'])
+        self.assertEqual(0, self.server.delete('/exp/stop').json['ret'])
 
         time.sleep(10)  # Ensure that timeout could have occured
         # Timeout never called
@@ -499,7 +499,7 @@ class TestExperimentTimeout(ExperimentRunningMock):
     def test__timeout_on_wrong_exp(self):
         """ Test _timeout_exp_stop only stops it's experiment """
 
-        self.assertEquals(0, self.server.post(EXP_START).json['ret'])
+        self.assertEqual(0, self.server.post(EXP_START).json['ret'])
 
         # simulate a previous experiment stop occuring too late
         self.g_m._timeout_exp_stop(exp_id=(EXP_ID - 1), user=USER)
@@ -507,7 +507,7 @@ class TestExperimentTimeout(ExperimentRunningMock):
         self.assertTrue(self._safe_exp_is_running)
 
         # cleanup
-        self.assertEquals(0, self.server.delete('/exp/stop').json['ret'])
+        self.assertEqual(0, self.server.delete('/exp/stop').json['ret'])
 
 
 class TestIntegrationOther(ExperimentRunningMock):
@@ -516,7 +516,7 @@ class TestIntegrationOther(ExperimentRunningMock):
     def test_status(self):
         """ Call the status command """
         ret = self.server.get('/status')
-        self.assertEquals(0, ret.json['ret'])
+        self.assertEqual(0, ret.json['ret'])
 
     def test_non_regular_start_stop(self):
         """ Test start calls when not needed
@@ -527,16 +527,16 @@ class TestIntegrationOther(ExperimentRunningMock):
         with patch.object(self.g_m, 'exp_stop', stop_mock):
 
             # create experiment
-            self.assertEquals(0, self.server.post(EXP_START).json['ret'])
-            self.assertEquals(stop_mock.call_count, 0)
+            self.assertEqual(0, self.server.post(EXP_START).json['ret'])
+            self.assertEqual(stop_mock.call_count, 0)
             # replace current experiment
-            self.assertEquals(0, self.server.post(EXP_START).json['ret'])
-            self.assertEquals(stop_mock.call_count, 1)
+            self.assertEqual(0, self.server.post(EXP_START).json['ret'])
+            self.assertEqual(stop_mock.call_count, 1)
 
             # stop exp
-            self.assertEquals(0, self.server.delete('/exp/stop').json['ret'])
+            self.assertEqual(0, self.server.delete('/exp/stop').json['ret'])
             # exp already stoped no error
-            self.assertEquals(0, self.server.delete('/exp/stop').json['ret'])
+            self.assertEqual(0, self.server.delete('/exp/stop').json['ret'])
 
     def test_invalid_tty_exp_a8(self):
         """ Test start where tty is not visible """
@@ -549,7 +549,7 @@ class TestIntegrationOther(ExperimentRunningMock):
             self.assertLessEqual(1, self.server.post(EXP_START).json['ret'])
 
         # stop and cleanup
-        self.assertEquals(0, self.server.delete('/exp/stop').json['ret'])
+        self.assertEqual(0, self.server.delete('/exp/stop').json['ret'])
 
 
 class TestInvalidCases(test_integration_mock.GatewayCodeMock):

--- a/gateway_code/open_nodes/tests/node_a8_test.py
+++ b/gateway_code/open_nodes/tests/node_a8_test.py
@@ -44,7 +44,7 @@ class TestNodeA8(unittest.TestCase):
 
         serial_expect.expect.return_value = ''
         ret = a8_node.wait_booted(0)
-        self.assertEquals(ret, '')
+        self.assertEqual(ret, '')
 
         serial_expect.expect.return_value = ' login: '
         ret = a8_node.wait_booted(0)

--- a/gateway_code/tests/board_config_test.py
+++ b/gateway_code/tests/board_config_test.py
@@ -43,17 +43,17 @@ class TestBoardConfig(unittest.TestCase):
     def test_board_type(self):
         board_cfg = board_config.BoardConfig()
 
-        self.assertEquals('m3', board_cfg.board_type)
-        self.assertEquals('m3', board_cfg.board_class.TYPE)
-        self.assertEquals('turtlebot2', board_cfg.robot_type)
-        self.assertNotEquals('', board_config.BoardConfig().node_id)
+        self.assertEqual('m3', board_cfg.board_type)
+        self.assertEqual('m3', board_cfg.board_class.TYPE)
+        self.assertEqual('turtlebot2', board_cfg.robot_type)
+        self.assertNotEqual('', board_config.BoardConfig().node_id)
 
     @mock.patch(utils.CFG_VAR_PATH, utils.test_cfg_dir('m3_no_robot'))
     def test_board_type_no_robot(self):
         board_cfg = board_config.BoardConfig()
 
-        self.assertEquals('m3', board_cfg.board_type)
-        self.assertEquals(None, board_cfg.robot_type)
+        self.assertEqual('m3', board_cfg.board_type)
+        self.assertEqual(None, board_cfg.robot_type)
 
     @mock.patch(utils.CFG_VAR_PATH, utils.test_cfg_dir('invalid_board_type'))
     def test_board_type_not_found(self):

--- a/gateway_code/tests/common_test.py
+++ b/gateway_code/tests/common_test.py
@@ -85,15 +85,15 @@ class TestWaitTTY(unittest.TestCase):
     def test_wait_tty(self):
         """ Test running wait_tty fct """
         logger = mock.Mock()
-        self.assertEquals(0, common.wait_tty('/dev/null', logger, 0))
-        self.assertEquals(0, logger.error.call_count)
-        self.assertEquals(1, common.wait_tty('no_tty_file', logger, 0))
-        self.assertEquals(1, logger.error.call_count)
+        self.assertEqual(0, common.wait_tty('/dev/null', logger, 0))
+        self.assertEqual(0, logger.error.call_count)
+        self.assertEqual(1, common.wait_tty('no_tty_file', logger, 0))
+        self.assertEqual(1, logger.error.call_count)
 
     def test_wait_no_tty(self):
         """ Test running wait_no_tty fct """
-        self.assertEquals(0, common.wait_no_tty('no_tty_file', 0))
-        self.assertEquals(1, common.wait_no_tty('/dev/null', 0))
+        self.assertEqual(0, common.wait_no_tty('no_tty_file', 0))
+        self.assertEqual(1, common.wait_no_tty('/dev/null', 0))
 
 
 class TestSynchronousDecorator(unittest.TestCase):
@@ -122,4 +122,4 @@ class TestSynchronousDecorator(unittest.TestCase):
         time.sleep(2)
         class_put.put_after_time('c')
 
-        self.assertEquals(['a', 'c'], class_put.item_list)
+        self.assertEqual(['a', 'c'], class_put.item_list)

--- a/gateway_code/tests/config_test.py
+++ b/gateway_code/tests/config_test.py
@@ -40,22 +40,22 @@ class TestConfig(unittest.TestCase):
 
     def test_read_config(self):
         with mock.patch(utils.CFG_VAR_PATH, utils.test_cfg_dir('m3_no_robot')):
-            self.assertEquals('m3', config.read_config('board_type'))
-            self.assertEquals('m3', config.read_config('board_type', 'def'))
+            self.assertEqual('m3', config.read_config('board_type'))
+            self.assertEqual('m3', config.read_config('board_type', 'def'))
 
             self.assertRaises(IOError, config.read_config, 'robot')
-            self.assertEquals(None, config.read_config('robot', None))
+            self.assertEqual(None, config.read_config('robot', None))
 
         with mock.patch(utils.CFG_VAR_PATH, utils.test_cfg_dir('m3_robot')):
-            self.assertEquals('m3', config.read_config('board_type'))
-            self.assertEquals('turtlebot2', config.read_config('robot'))
+            self.assertEqual('m3', config.read_config('board_type'))
+            self.assertEqual('turtlebot2', config.read_config('robot'))
 
     def test_default_profile(self):
         default_profile_dict = {
             u'power': u'dc',
             u'profilename': u'_default_profile',
         }
-        self.assertEquals(default_profile_dict, config.DEFAULT_PROFILE)
+        self.assertEqual(default_profile_dict, config.DEFAULT_PROFILE)
 
     @staticmethod
     def _rmfile(file_path):

--- a/gateway_code/tests/gateway_logging_test.py
+++ b/gateway_code/tests/gateway_logging_test.py
@@ -43,7 +43,7 @@ class TestGatewayLogging(unittest.TestCase):
         gateway_logging.init_logger('.')
         handlers_two = logger.handlers
 
-        self.assertEquals(handlers_one, handlers_two)
+        self.assertEqual(handlers_one, handlers_two)
 
     def test_user_logger(self):
         logger = logging.getLogger(__name__)
@@ -59,7 +59,7 @@ class TestGatewayLogging(unittest.TestCase):
 
             # file has data
             log_content = log_file.read()
-            self.assertNotEquals(0, len(log_content))
+            self.assertNotEqual(0, len(log_content))
             self.assertIn(test_log, log_content)
 
     @mock.patch('sys.stdout', new_callable=StringIO)
@@ -75,5 +75,5 @@ class TestGatewayLogging(unittest.TestCase):
 
         # sys.stdout received some data
         log_content = fake_stdout.getvalue()
-        self.assertNotEquals(0, len(log_content))
+        self.assertNotEqual(0, len(log_content))
         self.assertIn(test_log, log_content)

--- a/gateway_code/tests/gateway_manager_test.py
+++ b/gateway_code/tests/gateway_manager_test.py
@@ -62,7 +62,7 @@ class TestGatewayManager(unittest.TestCase):
         """ Update profile with an invalid profile """
 
         g_m = gateway_manager.GatewayManager()
-        self.assertEquals(1, g_m.exp_update_profile(profile_dict={}))
+        self.assertEqual(1, g_m.exp_update_profile(profile_dict={}))
 
 # # # # # # # # # # # # # # # # # # # # #
 # Measures folder and files management  #

--- a/gateway_code/tests/rest_server_test.py
+++ b/gateway_code/tests/rest_server_test.py
@@ -125,30 +125,30 @@ class TestRestMethods(unittest.TestCase):
         files += [('profile', 'profile.json', self.PROFILE_STR)]
 
         ret = self.server.post(self.EXP_START, upload_files=files)
-        self.assertEquals(0, ret.json['ret'])
+        self.assertEqual(0, ret.json['ret'])
 
         # validate arguments
         call_args = self.g_m.exp_start.call_args[0]
-        self.assertEquals(('user', 123), call_args[0: 2])
+        self.assertEqual(('user', 123), call_args[0: 2])
         self.assertTrue('idle.elf' in call_args[2])
-        self.assertEquals(self.PROFILE_DICT, call_args[3])
+        self.assertEqual(self.PROFILE_DICT, call_args[3])
 
     def test_exp_start_invalid_profile(self):
 
         files = [('profile', 'inval_profile.json', 'invalid json profile}')]
         ret = self.server.post(self.EXP_START, upload_files=files)
-        self.assertEquals(1, ret.json['ret'])
+        self.assertEqual(1, ret.json['ret'])
 
     def test_exp_start_no_files(self):
         self.g_m.exp_start.return_value = 0
 
         # nothing in files
         ret = self.server.post(self.EXP_START, upload_files=[])
-        self.assertEquals(0, ret.json['ret'])
+        self.assertEqual(0, ret.json['ret'])
 
         # validate
         self.g_m.exp_start.assert_called_with('user', 123, None, None, 0)
-        self.assertEquals(0, ret.json['ret'])
+        self.assertEqual(0, ret.json['ret'])
 
     def test_exp_start_valid_duration(self):
         self.g_m.exp_start.return_value = 0
@@ -172,22 +172,22 @@ class TestRestMethods(unittest.TestCase):
         ret = self.server.post(self.EXP_START,
                                content_type='multipart/form-data')
 
-        self.assertEquals(0, ret.json['ret'])
+        self.assertEqual(0, ret.json['ret'])
         self.g_m.exp_start.assert_called_with('user', 123, None, None, 0)
 
     def test_exp_stop(self):
         self.g_m.exp_stop.return_value = 0
         ret = self.server.delete('/exp/stop')
-        self.assertEquals(0, ret.json['ret'])
+        self.assertEqual(0, ret.json['ret'])
 
         self.g_m.exp_stop.return_value = 1
         ret = self.server.delete('/exp/stop')
-        self.assertEquals(1, ret.json['ret'])
+        self.assertEqual(1, ret.json['ret'])
 
     def test_exp_stop_wrong_request_type(self):
         ret = self.server.post('/exp/stop', status='*')
-        self.assertEquals(405, ret.status_int)
-        self.assertEquals('405 Method Not Allowed', ret.status)
+        self.assertEqual(405, ret.status_int)
+        self.assertEqual('405 Method Not Allowed', ret.status)
 
 # Simple functions
 
@@ -198,23 +198,23 @@ class TestRestMethods(unittest.TestCase):
 
         # No profile
         ret = self.server.post('/exp/update', content_type=app_json)
-        self.assertEquals(0, ret.json['ret'])
+        self.assertEqual(0, ret.json['ret'])
         self.assertTrue(self.g_m.exp_update_profile.called)
         self.g_m.exp_update_profile.reset_mock()
 
         # default profile
         ret = self.server.post('/exp/update', self.PROFILE_STR,
                                content_type=app_json)
-        self.assertEquals(0, ret.json['ret'])
+        self.assertEqual(0, ret.json['ret'])
         self.assertTrue(self.g_m.exp_update_profile.called)
 
         call_args = self.g_m.exp_update_profile.call_args[0]
-        self.assertEquals(self.PROFILE_DICT, call_args[0])
+        self.assertEqual(self.PROFILE_DICT, call_args[0])
         self.g_m.exp_update_profile.reset_mock()
 
         # profile that cannot be decoded, invalid JSON
         ret = self.server.post('/exp/update', 'inval }', content_type=app_json)
-        self.assertEquals(1, ret.json['ret'])
+        self.assertEqual(1, ret.json['ret'])
         self.assertFalse(self.g_m.exp_update_profile.called)
         self.g_m.exp_update_profile.reset_mock()
 
@@ -224,42 +224,42 @@ class TestRestMethods(unittest.TestCase):
 
         # valid command
         ret = self.server.post('/open/flash', upload_files=files)
-        self.assertEquals(0, ret.json['ret'])
+        self.assertEqual(0, ret.json['ret'])
 
         # Error no firmware
         ret = self.server.post('/open/flash', upload_files=[])
-        self.assertEquals(1, ret.json['ret'])
+        self.assertEqual(1, ret.json['ret'])
 
     def test_flash_idle(self):
         self.g_m.node_flash.return_value = 0
 
         ret = self.server.put('/open/flash/idle')
-        self.assertEquals(0, ret.json['ret'])
+        self.assertEqual(0, ret.json['ret'])
         self.g_m.node_flash.assert_called_with('open', None)
 
     def test_reset_wrappers(self):
         self.g_m.node_soft_reset.return_value = 0
 
         ret = self.server.put('/open/reset')
-        self.assertEquals(0, ret.json['ret'])
+        self.assertEqual(0, ret.json['ret'])
 
     def test_open_start(self):
         self.g_m.open_power_start.return_value = 0
 
         ret = self.server.put('/open/start')
-        self.assertEquals(0, ret.json['ret'])
+        self.assertEqual(0, ret.json['ret'])
 
     def test_open_stop(self):
         self.g_m.open_power_stop.return_value = 0
 
         ret = self.server.put('/open/stop')
-        self.assertEquals(0, ret.json['ret'])
+        self.assertEqual(0, ret.json['ret'])
 
     def test_status(self):
         self.g_m.status.return_value = 0
 
         ret = self.server.get('/status')
-        self.assertEquals(0, ret.json['ret'])
+        self.assertEqual(0, ret.json['ret'])
 
     def test_auto_test(self):
         self.g_m.auto_tests.return_value = {
@@ -268,33 +268,33 @@ class TestRestMethods(unittest.TestCase):
         }
 
         ret = self.server.put('/autotest')
-        self.assertEquals(0, ret.json['ret'])
+        self.assertEqual(0, ret.json['ret'])
         self.g_m.auto_tests.assert_called_with(None, False, False, False)
 
         extra = query_string('channel=22&flash=1&gps=')
         ret = self.server.put('/autotest/blink', extra_environ=extra)
-        self.assertEquals(0, ret.json['ret'])
+        self.assertEqual(0, ret.json['ret'])
         self.g_m.auto_tests.assert_called_with(22, True, True, False)
 
         # invalid calls
         ret = self.server.put('/autotest/invalid_mode')
-        self.assertNotEquals(0, ret.json['ret'])
+        self.assertNotEqual(0, ret.json['ret'])
 
         extra = query_string('channel=abc')
         ret = self.server.put('/autotest', extra_environ=extra)
-        self.assertEquals(1, ret.json['ret'])
+        self.assertEqual(1, ret.json['ret'])
 
         extra = query_string('channel=42')
         ret = self.server.put('/autotest', extra_environ=extra)
-        self.assertEquals(1, ret.json['ret'])
+        self.assertEqual(1, ret.json['ret'])
 
         extra = query_string('channel=11&gps=true')
         ret = self.server.put('/autotest', extra_environ=extra)
-        self.assertEquals(1, ret.json['ret'])
+        self.assertEqual(1, ret.json['ret'])
 
         extra = query_string('channel=11&flash=false')
         ret = self.server.put('/autotest', extra_environ=extra)
-        self.assertEquals(1, ret.json['ret'])
+        self.assertEqual(1, ret.json['ret'])
 
 
 class TestServerRestMain(unittest.TestCase):

--- a/gateway_code/tests/utils_test.py
+++ b/gateway_code/tests/utils_test.py
@@ -31,12 +31,12 @@ class TestUtilsMock(unittest.TestCase):
     def test_read_config_mock(self):
 
         read_cfg = utils.read_config_mock('m3', test_key='value')
-        self.assertEquals('m3', read_cfg('board_type'))
+        self.assertEqual('m3', read_cfg('board_type'))
 
         # No robot by default
         self.assertRaises(IOError, read_cfg, 'robot')
-        self.assertEquals(None, read_cfg('robot', None))
+        self.assertEqual(None, read_cfg('robot', None))
 
         # Extra key
-        self.assertEquals('value', read_cfg('test_key'))
-        self.assertEquals('value', read_cfg('test_key', 'default'))
+        self.assertEqual('value', read_cfg('test_key'))
+        self.assertEqual('value', read_cfg('test_key', 'default'))

--- a/gateway_code/utils/tests/avrdude_test.py
+++ b/gateway_code/utils/tests/avrdude_test.py
@@ -50,11 +50,11 @@ class TestsMethods(unittest.TestCase):
         """Test flash."""
         call_mock.return_value = 0
         ret = self.avr.flash(NodeLeonardo.FW_IDLE)
-        self.assertEquals(0, ret)
+        self.assertEqual(0, ret)
 
         call_mock.return_value = 42
         ret = self.avr.flash(NodeLeonardo.FW_IDLE)
-        self.assertEquals(42, ret)
+        self.assertEqual(42, ret)
 
     def test_invalid_firmware_path(self):
         ret = self.avr.flash('/invalid/path')
@@ -78,7 +78,7 @@ class TestsCall(unittest.TestCase):
 
         # Not to much more
         self.assertLess(t_end - t_0, self.timeout + 1)
-        self.assertNotEquals(ret, 0)
+        self.assertNotEqual(ret, 0)
 
     def test_no_timeout(self):
         """Test timeout not reached."""
@@ -89,7 +89,7 @@ class TestsCall(unittest.TestCase):
 
         # Strictly lower here
         self.assertLess(t_end - t_0, self.timeout - 1)
-        self.assertEquals(ret, 0)
+        self.assertEqual(ret, 0)
 
 
 @mock.patch('serial.Serial')
@@ -122,7 +122,7 @@ class TestTriggerBootloader(unittest.TestCase):
 
         ret = avrdude.AvrDude.trigger_bootloader(self.tty, self.tty_prog,
                                                  timeout=2)
-        self.assertEquals(0, ret)
+        self.assertEqual(0, ret)
         self.assertTrue(os.path.exists(self.tty_prog))
 
     def test_trigger_fail(self, serial_mock):
@@ -131,7 +131,7 @@ class TestTriggerBootloader(unittest.TestCase):
 
         ret = avrdude.AvrDude.trigger_bootloader(self.tty, self.tty_prog,
                                                  timeout=1)
-        self.assertNotEquals(0, ret)
+        self.assertNotEqual(0, ret)
         self.assertFalse(os.path.exists(self.tty_prog))
 
     def test_serial_error_opening_tty(self, serial_mock):

--- a/gateway_code/utils/tests/cc2538_test.py
+++ b/gateway_code/utils/tests/cc2538_test.py
@@ -39,10 +39,10 @@ class TestCC2538(unittest.TestCase):
         """ test the objdump get_elf_load_addr """
         elf = os.path.abspath(static_path('firefly_autotest.elf'))
         elf_addr = get_elf_load_addr(elf)
-        self.assertEquals(0x00200000, elf_addr)
+        self.assertEqual(0x00200000, elf_addr)
         elf = os.path.abspath(static_path('firefly_idle.elf'))
         elf_addr = get_elf_load_addr(elf)
-        self.assertEquals(0x00202000, elf_addr)
+        self.assertEqual(0x00202000, elf_addr)
 
 
 @mock.patch('gateway_code.utils.subprocess_timeout.call')
@@ -57,22 +57,22 @@ class TestsCC2538Methods(unittest.TestCase):
         """Test flash."""
         call_mock.return_value = 0
         ret = self.cc2538.flash(NodeFirefly.FW_IDLE)
-        self.assertEquals(0, ret)
+        self.assertEqual(0, ret)
 
         call_mock.return_value = 42
         ret = self.cc2538.flash(NodeFirefly.FW_AUTOTEST)
         # call is called twice and the ret codes are summed up
-        self.assertEquals(84, ret)
+        self.assertEqual(84, ret)
 
     def test_reset(self, call_mock):
         """ Test reset"""
         call_mock.return_value = 0
         ret = self.cc2538.reset()
-        self.assertEquals(0, ret)
+        self.assertEqual(0, ret)
 
         call_mock.return_value = 42
         ret = self.cc2538.reset()
-        self.assertEquals(42, ret)
+        self.assertEqual(42, ret)
 
     def test_invalid_firmware_path(self, _):
         """Test flash an invalid firmware return a non zero value."""
@@ -99,7 +99,7 @@ class TestsCC2538Call(unittest.TestCase):
 
         # Not to much more
         self.assertLess(t_end - t_0, self.timeout + 1)
-        self.assertNotEquals(ret, 0)
+        self.assertNotEqual(ret, 0)
 
     def test_no_timeout(self):
         """Test timeout not reached."""
@@ -110,4 +110,4 @@ class TestsCC2538Call(unittest.TestCase):
 
         # Strictly lower here
         self.assertLess(t_end - t_0, self.timeout - 1)
-        self.assertEquals(ret, 0)
+        self.assertEqual(ret, 0)

--- a/gateway_code/utils/tests/cli_avrdude_test.py
+++ b/gateway_code/utils/tests/cli_avrdude_test.py
@@ -52,9 +52,9 @@ class TestsAvrDudecli(unittest.TestCase):
         with mock.patch('sys.argv', args):
             self.avrdude.flash.return_value = 0
             ret = avrdude.main()
-            self.assertEquals(ret, 0)
+            self.assertEqual(ret, 0)
             self.assertTrue(self.avrdude.flash.called)
 
             self.avrdude.flash.return_value = 42
             ret = avrdude.main()
-            self.assertEquals(ret, 42)
+            self.assertEqual(ret, 42)

--- a/gateway_code/utils/tests/cli_cc2538_test.py
+++ b/gateway_code/utils/tests/cli_cc2538_test.py
@@ -48,12 +48,12 @@ class TestsCC2538cli(unittest.TestCase):
         with mock.patch('sys.argv', args):
             self.cc2538.flash.return_value = 0
             ret = cc2538.main()
-            self.assertEquals(ret, 0)
+            self.assertEqual(ret, 0)
             self.assertTrue(self.cc2538.flash.called)
 
             self.cc2538.flash.return_value = 42
             ret = cc2538.main()
-            self.assertEquals(ret, 42)
+            self.assertEqual(ret, 42)
 
     def test_reset(self):
         """ Running command line reset """
@@ -64,9 +64,9 @@ class TestsCC2538cli(unittest.TestCase):
         with mock.patch('sys.argv', args):
             self.cc2538.reset.return_value = 0
             ret = cc2538.main()
-            self.assertEquals(ret, 0)
+            self.assertEqual(ret, 0)
             self.assertTrue(self.cc2538.reset.called)
 
             self.cc2538.reset.return_value = 42
             ret = cc2538.main()
-            self.assertEquals(ret, 42)
+            self.assertEqual(ret, 42)

--- a/gateway_code/utils/tests/cli_mjpg_streamer_test.py
+++ b/gateway_code/utils/tests/cli_mjpg_streamer_test.py
@@ -63,4 +63,4 @@ class TestMjpgStreamerParsing(unittest.TestCase):
     def test_parser(self):
         """ Test cli.mjpg_streamer PARSER """
         opts = mjpg_streamer.PARSER.parse_args(['40000'])
-        self.assertEquals(40000, opts.port)
+        self.assertEqual(40000, opts.port)

--- a/gateway_code/utils/tests/cli_openocd_test.py
+++ b/gateway_code/utils/tests/cli_openocd_test.py
@@ -48,12 +48,12 @@ class TestsOpenOCDcli(unittest.TestCase):
             with mock.patch('sys.argv', args):
                 self.ocd.flash.return_value = 0
                 ret = openocd.main()
-                self.assertEquals(ret, 0)
+                self.assertEqual(ret, 0)
                 self.assertTrue(self.ocd.flash.called)
 
                 self.ocd.flash.return_value = 42
                 ret = openocd.main()
-                self.assertEquals(ret, 42)
+                self.assertEqual(ret, 42)
 
     def test_reset(self):
         """ Running command line reset """
@@ -65,12 +65,12 @@ class TestsOpenOCDcli(unittest.TestCase):
             with mock.patch('sys.argv', args):
                 self.ocd.reset.return_value = 0
                 ret = openocd.main()
-                self.assertEquals(ret, 0)
+                self.assertEqual(ret, 0)
                 self.assertTrue(self.ocd.reset.called)
 
                 self.ocd.reset.return_value = 42
                 ret = openocd.main()
-                self.assertEquals(ret, 42)
+                self.assertEqual(ret, 42)
 
     @mock.patch("signal.pause")
     def test_debug(self, pause):

--- a/gateway_code/utils/tests/cli_rtl_tcp_test.py
+++ b/gateway_code/utils/tests/cli_rtl_tcp_test.py
@@ -63,5 +63,5 @@ class TestRtlTcpParsing(unittest.TestCase):
     def test_parser(self):
         """ Test cli.rtl_tcp PARSER """
         opts = rtl_tcp.PARSER.parse_args(['50000', '868000000'])
-        self.assertEquals(50000, opts.port)
-        self.assertEquals(868000000, opts.frequency)
+        self.assertEqual(50000, opts.port)
+        self.assertEqual(868000000, opts.frequency)

--- a/gateway_code/utils/tests/cli_serial_redirection_test.py
+++ b/gateway_code/utils/tests/cli_serial_redirection_test.py
@@ -63,5 +63,5 @@ class TestArgumentsParsing(unittest.TestCase):
     def test_parser(self):
         """ Test cli.serial_redirection PARSER """
         opts = serial_redirection.PARSER.parse_args(['tty', '500000'])
-        self.assertEquals('tty', opts.tty)
-        self.assertEquals(500000, opts.baudrate)
+        self.assertEqual('tty', opts.tty)
+        self.assertEqual(500000, opts.baudrate)

--- a/gateway_code/utils/tests/edbg_test.py
+++ b/gateway_code/utils/tests/edbg_test.py
@@ -47,12 +47,12 @@ class TestsMethods(unittest.TestCase):
         """Test flash."""
         call_mock.return_value = 0
         ret = self.edbg.flash(NodeSamr21.FW_IDLE)
-        self.assertEquals(0, ret)
+        self.assertEqual(0, ret)
 
         call_mock.return_value = 42
         ret = self.edbg.flash(NodeSamr21.FW_AUTOTEST)
         # call is called twice and the ret codes are summed up
-        self.assertEquals(84, ret)
+        self.assertEqual(84, ret)
 
     def test_invalid_firmware_path(self):
         ret = self.edbg.flash('/invalid/path')
@@ -75,7 +75,7 @@ class TestsCall(unittest.TestCase):
 
         # Not to much more
         self.assertLess(t_end - t_0, self.timeout + 1)
-        self.assertNotEquals(ret, 0)
+        self.assertNotEqual(ret, 0)
 
     def test_no_timeout(self):
         """Test timeout not reached."""
@@ -86,4 +86,4 @@ class TestsCall(unittest.TestCase):
 
         # Strictly lower here
         self.assertLess(t_end - t_0, self.timeout - 1)
-        self.assertEquals(ret, 0)
+        self.assertEqual(ret, 0)

--- a/gateway_code/utils/tests/external_process_test.py
+++ b/gateway_code/utils/tests/external_process_test.py
@@ -158,7 +158,7 @@ class TestProcessSocat(unittest.TestCase):
         m_redirect._run = True
 
         ret = m_redirect._call_process(m_redirect.stdout)
-        self.assertEquals(-1, ret)
+        self.assertEqual(-1, ret)
 
     def test__call_socat_error_tty_not_found(self, m_popen):
         """ Test the _call_process error case when path can't be found"""
@@ -167,7 +167,7 @@ class TestProcessSocat(unittest.TestCase):
         m_redirect._run = True
 
         ret = m_redirect._call_process(m_redirect.stdout)
-        self.assertEquals(-1, ret)
+        self.assertEqual(-1, ret)
 
 
 @mock.patch('subprocess.Popen')
@@ -181,7 +181,7 @@ class TestProcessRtlTcp(unittest.TestCase):
         m_rtl_tcp._run = True
 
         ret = m_rtl_tcp._call_process(m_rtl_tcp.stdout)
-        self.assertEquals(-1, ret)
+        self.assertEqual(-1, ret)
 
 
 @mock.patch('subprocess.Popen')
@@ -197,4 +197,4 @@ class TestProcessMjpgStreamer(unittest.TestCase):
         m_mjpg_streamer._run = True
 
         ret = m_mjpg_streamer._call_process(m_mjpg_streamer.stdout)
-        self.assertEquals(-1, ret)
+        self.assertEqual(-1, ret)

--- a/gateway_code/utils/tests/ftdi_check_test.py
+++ b/gateway_code/utils/tests/ftdi_check_test.py
@@ -46,7 +46,7 @@ class TestFtdiCheck(unittest.TestCase):
                 Serial:
             All done, success!
             ''')
-        self.assertEquals(0, ftdi_check('control', '4232'))
+        self.assertEqual(0, ftdi_check('control', '4232'))
         m_check_output.assert_called_with(['ftdi-devices-list', '-t', '4232'])
 
     def test__ftdi_is_absent(self, m_check_output):
@@ -57,7 +57,7 @@ class TestFtdiCheck(unittest.TestCase):
             No FTDI device found
             All done, success!
             ''')
-        self.assertEquals(1, ftdi_check('open', '2232'))
+        self.assertEqual(1, ftdi_check('open', '2232'))
         m_check_output.assert_called_with(['ftdi-devices-list', '-t', '2232'])
 
     def test_ftdi_list_present(self, m_check_output):
@@ -77,6 +77,6 @@ class TestFtdiCheck(unittest.TestCase):
                 Serial:
             All done, success!
             ''')
-        self.assertEquals(0, ftdi_check('control', '4232'))
-        self.assertEquals(0, ftdi_check('control', '4232', description='M3'))
+        self.assertEqual(0, ftdi_check('control', '4232'))
+        self.assertEqual(0, ftdi_check('control', '4232', description='M3'))
         m_check_output.assert_called_with(['ftdi-devices-list', '-t', '4232'])

--- a/gateway_code/utils/tests/node_connection_test.py
+++ b/gateway_code/utils/tests/node_connection_test.py
@@ -80,59 +80,59 @@ class TestOpenNodeConnection(unittest.TestCase):
 
             cmd = ['cmd']
             ret = conn.send_command(cmd)
-            self.assertEquals(['READ_LINE'] + cmd, ret)
+            self.assertEqual(['READ_LINE'] + cmd, ret)
 
             cmd = ['command', 'arg1', 'arg2']
             ret = conn.send_command(cmd)
-            self.assertEquals(['READ_LINE'] + cmd, ret)
+            self.assertEqual(['READ_LINE'] + cmd, ret)
 
             cmd = ['command3', 'arg1', 'arg2', 'arg3', 'arg4']
             ret = conn.send_command(cmd)
-            self.assertEquals(['READ_LINE'] + cmd, ret)
+            self.assertEqual(['READ_LINE'] + cmd, ret)
 
     def test_sending_with_delay(self):
         with OpenNodeConnection() as conn:
 
             self.write_delay = 1
             ret = conn.send_command(['cmd'])
-            self.assertEquals(['READ_LINE', 'cmd'], ret)
+            self.assertEqual(['READ_LINE', 'cmd'], ret)
 
             self.write_delay = 2
             ret = conn.send_command(['cmd'])
-            self.assertEquals(['READ_LINE', 'cmd'], ret)
+            self.assertEqual(['READ_LINE', 'cmd'], ret)
 
             self.write_delay = 3
             ret = conn.send_command(['cmd'])
-            self.assertEquals(['READ_LINE', 'cmd'], ret)
+            self.assertEqual(['READ_LINE', 'cmd'], ret)
 
             self.write_delay = 4
             ret = conn.send_command(['cmd'])
-            self.assertEquals(['READ_LINE', 'cmd'], ret)
+            self.assertEqual(['READ_LINE', 'cmd'], ret)
 
     def test_sending_one_command(self):
         cmd = ['cmd']
         ret = OpenNodeConnection.send_one_command(cmd)
-        self.assertEquals(['READ_LINE'] + cmd, ret)
+        self.assertEqual(['READ_LINE'] + cmd, ret)
 
         cmd = ['command', 'arg1', 'arg2']
         ret = OpenNodeConnection.send_one_command(cmd)
-        self.assertEquals(['READ_LINE'] + cmd, ret)
+        self.assertEqual(['READ_LINE'] + cmd, ret)
 
         cmd = ['command3', 'arg1', 'arg2', 'arg3', 'arg4']
         ret = OpenNodeConnection.send_one_command(cmd)
-        self.assertEquals(['READ_LINE'] + cmd, ret)
+        self.assertEqual(['READ_LINE'] + cmd, ret)
 
     def test_no_answer(self):
         # Disable node answers
         self.redirect.stdin = mock.Mock()
 
         ret = OpenNodeConnection.send_one_command(['cmd'], timeout=0.1)
-        self.assertEquals(None, ret)
+        self.assertEqual(None, ret)
 
     def test_timeout(self):
         self.write_delay = 0.2
         ret = OpenNodeConnection.send_one_command(['cmd'], timeout=0.1)
-        self.assertEquals(None, ret)
+        self.assertEqual(None, ret)
 
     @pytest.mark.usefixtures("my_capsys")
     def test_ioerror_thread_mock(self):
@@ -143,7 +143,7 @@ class TestOpenNodeConnection(unittest.TestCase):
         ret = OpenNodeConnection.send_one_command(['cmd'], timeout=0.1)
         out, _ = self.capsys.readouterr()
         assert out == "Test Error\n"
-        self.assertEquals(None, ret)
+        self.assertEqual(None, ret)
 
 
 class TestOpenNodeConnectionErrors(unittest.TestCase):

--- a/gateway_code/utils/tests/openocd_test.py
+++ b/gateway_code/utils/tests/openocd_test.py
@@ -46,31 +46,31 @@ class TestsMethods(unittest.TestCase):
         """ Test flash """
         call_mock.return_value = 0
         ret = self.ocd.flash(NodeM3.FW_IDLE)
-        self.assertEquals(0, ret)
+        self.assertEqual(0, ret)
 
         call_mock.return_value = 42
         ret = self.ocd.flash(NodeM3.FW_IDLE)
-        self.assertEquals(42, ret)
+        self.assertEqual(42, ret)
 
     def test_reset(self, call_mock):
         """ Test reset"""
         call_mock.return_value = 0
         ret = self.ocd.reset()
-        self.assertEquals(0, ret)
+        self.assertEqual(0, ret)
 
         call_mock.return_value = 42
         ret = self.ocd.reset()
-        self.assertEquals(42, ret)
+        self.assertEqual(42, ret)
 
     @mock.patch('subprocess.Popen')
     def test_debug(self, popen_mock, call_mock):
         """Test debug."""
         # Stop without debugging
         ret = self.ocd.debug_stop()
-        self.assertEquals(0, ret)
+        self.assertEqual(0, ret)
 
         ret = self.ocd.debug_start()
-        self.assertEquals(0, ret)
+        self.assertEqual(0, ret)
         self.assertTrue(popen_mock.called)
 
         # Verify command
@@ -86,12 +86,12 @@ class TestsMethods(unittest.TestCase):
         ret = self.ocd.reset()
         self.assertEqual(ret, 1)
         ret = self.ocd.flash(NodeM3.FW_IDLE)
-        self.assertEquals(1, ret)
+        self.assertEqual(1, ret)
         # not executed
         self.assertFalse(call_mock.called)
 
         ret = self.ocd.debug_stop()
-        self.assertEquals(0, ret)
+        self.assertEqual(0, ret)
 
     @mock.patch('subprocess.Popen')
     def test_debug_error_stop(self, popen_mock, _):
@@ -119,7 +119,7 @@ class TestsCall(unittest.TestCase):
 
         # Not to much more
         self.assertLess(t_end - t_0, self.timeout + 1)
-        self.assertNotEquals(ret, 0)
+        self.assertNotEqual(ret, 0)
 
     def test_no_timeout(self):
         """Test timeout not reached."""
@@ -130,7 +130,7 @@ class TestsCall(unittest.TestCase):
 
         # Strictly lower here
         self.assertLess(t_end - t_0, self.timeout - 1)
-        self.assertEquals(ret, 0)
+        self.assertEqual(ret, 0)
 
 
 class TestsFlashInvalidPaths(unittest.TestCase):

--- a/gateway_code/utils/tests/serial_expect_test.py
+++ b/gateway_code/utils/tests/serial_expect_test.py
@@ -72,7 +72,7 @@ class TestSerialExpect(unittest.TestCase):
     def test_expect(self):
         self.read_ret = ['abcde12345']
         ret = self.expect.expect('ab.*45')
-        self.assertEquals('abcde12345', ret)
+        self.assertEqual('abcde12345', ret)
 
     def test_expect_empty(self):
         self.read_ret = []
@@ -81,28 +81,28 @@ class TestSerialExpect(unittest.TestCase):
     def test_expect_timeout(self):
         self.read_ret = ['wrong_text']
         ret = self.expect.expect('ab.*45', 0.0)
-        self.assertEquals('', ret)  # timeout
+        self.assertEqual('', ret)  # timeout
 
     def test_expect_on_multiple_reads(self):
         self.read_ret = ['a234567890123456', '', 'b234567890123456', '123456c']
         expected_ret = ''.join(self.read_ret)
 
         ret = self.expect.expect('a.*c')
-        self.assertEquals(expected_ret, ret)
+        self.assertEqual(expected_ret, ret)
 
     def test_expect_list(self):
         self.read_ret = ['aaaa']
         ret = self.expect.expect_list(['a', 'b'])
-        self.assertEquals('a', ret)
+        self.assertEqual('a', ret)
 
         self.read_ret = ['b']
         ret = self.expect.expect_list(['a', 'b'])
-        self.assertEquals('b', ret)
+        self.assertEqual('b', ret)
 
     def test_expect_read_new_line(self):
         self.read_ret = ['ab\ncd', 'a00d']
         ret = self.expect.expect('a.*d')
-        self.assertEquals('a00d', ret)
+        self.assertEqual('a00d', ret)
 
     def test_expect_newline_pattern(self):
         self.assertRaises(ValueError, self.expect.expect, 'abc\rdef\nghi')
@@ -121,7 +121,7 @@ class TestSerialExpect(unittest.TestCase):
         self.serial.read = mock.Mock(side_effect=serial.SerialException(
             "FD already closed"))
         ret = self.expect.expect('a.*d')
-        self.assertEquals('', ret)
+        self.assertEqual('', ret)
 
     def test_close_attribute_error(self):
         # Smoke test for close when and AttributeError exception is raised.
@@ -135,7 +135,7 @@ class TestSerialExpect(unittest.TestCase):
 
         self.read_ret = ['123\n456', '789\n', 'abcd']
         ret = self.expect.expect('a.*d')
-        self.assertEquals(ret, 'abcd')
+        self.assertEqual(ret, 'abcd')
 
         logger.debug.assert_any_call('123')
         logger.debug.assert_any_call('456789')
@@ -145,4 +145,4 @@ class TestSerialExpect(unittest.TestCase):
         with serial_expect.SerialExpect('TTY', 1234) as ser:
             self.read_ret = ['123\n456', '789\n', 'abcd']
             ret = ser.expect('a.*d')
-            self.assertEquals(ret, 'abcd')
+            self.assertEqual(ret, 'abcd')

--- a/gateway_code/utils/tests/serial_redirection_test.py
+++ b/gateway_code/utils/tests/serial_redirection_test.py
@@ -85,14 +85,14 @@ class TestSerialRedirection(_SerialRedirectionTestCase):
             sock_txt = 'HelloFromSock: %u\n' % i
             conn.send(sock_txt)
             ret = self.serial.stdout.read(len(sock_txt))
-            self.assertEquals(ret, sock_txt)
+            self.assertEqual(ret, sock_txt)
             logging.debug(ret)
 
             # Serial send
             serial_txt = 'HelloFromSerial %u\n' % i
             self.serial.stdin.write(serial_txt)
             ret = conn.recv(len(serial_txt))
-            self.assertEquals(ret, serial_txt)
+            self.assertEqual(ret, serial_txt)
             logging.debug(ret)
 
             conn.close()
@@ -102,12 +102,12 @@ class TestSerialRedirection(_SerialRedirectionTestCase):
     def test_serialredirection_multiple_uses(self):
         """ Test calling multiple times start-stop """
         self.redirect = SerialRedirection(self.tty, self.baud)
-        self.assertEquals(0, self.redirect.start())
-        self.assertEquals(0, self.redirect.stop())
-        self.assertEquals(0, self.redirect.start())
-        self.assertEquals(0, self.redirect.stop())
-        self.assertEquals(0, self.redirect.start())
-        self.assertEquals(0, self.redirect.stop())
+        self.assertEqual(0, self.redirect.start())
+        self.assertEqual(0, self.redirect.stop())
+        self.assertEqual(0, self.redirect.start())
+        self.assertEqual(0, self.redirect.stop())
+        self.assertEqual(0, self.redirect.start())
+        self.assertEqual(0, self.redirect.stop())
 
     def test_serialredirection_exclusion(self):
         """ Check the exclusion of multiple connection on SerialRedirection """


### PR DESCRIPTION
The corresponding methods are assertEqual/assertNotEqual.

I think I get this because I updated my system to ubuntu cosmic which comes with a new python 2.7 version. It doesn't seem to be a bad idea to update. Also tested directly on a gateway and works there as well.

The update was performed semi-automatically using:
```
$ git grep -l 'self.assertEquals(' | xargs sed -i 's/self.assertEquals(/self.assertEqual(/g'
$ git grep -l 'self.assertNotEquals(' | xargs sed -i 's/self.assertNotEquals(/self.assertNotEqual(/g'
```