### PR TITLE
fallback key servers for gosu

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -31,7 +31,16 @@ RUN apt-get -y --no-install-recommends install \
     ca-certificates \
     curl
 
-RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+RUN export KEY=B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+    for server in $(shuf -e ha.pool.sks-keyservers.net \
+                            hkp://p80.pool.sks-keyservers.net:80 \
+                            keyserver.ubuntu.com \
+                            hkp://keyserver.ubuntu.com:80 \
+                            keyserver.pgp.com \
+                            pgp.mit.edu) ; do \
+        gpg --batch --keyserver "$server" --recv-keys $KEY && break || : ; \
+    done;
+
 RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.4/gosu-$(dpkg --print-architecture)" \
     && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.4/gosu-$(dpkg --print-architecture).asc" \
     && gpg --verify /usr/local/bin/gosu.asc \


### PR DESCRIPTION
this is for the Docker testing system: this fixes the problem of the gosu GPG key not being found sometimes, by using multiple fallback servers, seen in a build of #89 