### PR TITLE
utils: add helpers.call_cmd function

### DIFF
--- a/gateway_code/utils/avrdude.py
+++ b/gateway_code/utils/avrdude.py
@@ -24,14 +24,13 @@
 """ AvrDude commands """
 
 import os
-import shlex
 
 import logging
 import serial
 
 from gateway_code import common
 from gateway_code.common import logger_call
-from . import subprocess_timeout
+from gateway_code.utils import helpers
 
 LOGGER = logging.getLogger('gateway_code')
 
@@ -52,32 +51,20 @@ class AvrDude(object):
         self.conf = avrdude_conf
         self.out = None if verb else self.DEVNULL
 
+    def _call_cmd(self, command_str):
+        return helpers.call_cmd(command_str,
+                                out=self.out, timeout=self.timeout)
+
     @logger_call("AvrDude : flash")
     def flash(self, hex_file):
         """ Flash firmware """
         try:
             hex_path = common.abspath(hex_file)
-            return self._call_cmd(self.FLASH.format(hex_path))
+            return self._call_cmd(self.AVRDUDE.format(
+                cmd=self.FLASH.format(hex_path), **self.conf))
         except IOError as err:
             LOGGER.error('%s', err)
             return 1
-
-    def _call_cmd(self, command_str):
-        """ Create the subprocess """
-        kwargs = self._avrdude_args(command_str)
-        try:
-            return subprocess_timeout.call(timeout=self.timeout,
-                                           **kwargs)
-        except subprocess_timeout.TimeoutExpired as exc:
-            LOGGER.error("Openocd '%s' timeout: %s", command_str, exc)
-            return 1
-
-    def _avrdude_args(self, command_str):
-        """ Get subprocess arguments for command_str """
-        # Generate full command arguments
-        cmd = self.AVRDUDE.format(cmd=command_str, **self.conf)
-        args = shlex.split(cmd)
-        return {'args': args, 'stdout': self.out, 'stderr': self.out}
 
     @staticmethod
     def trigger_bootloader(tty, tty_prog, timeout=10, baudrate=1200):

--- a/gateway_code/utils/helpers.py
+++ b/gateway_code/utils/helpers.py
@@ -1,0 +1,41 @@
+# -*- coding:utf-8 -*-
+
+# This file is a part of IoT-LAB gateway_code
+# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Contributor(s) : see AUTHORS file
+#
+# This software is governed by the CeCILL license under French law
+# and abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# http://www.cecill.info.
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+
+
+"""Helper module for calling a command in a subprocess."""
+
+import shlex
+
+import logging
+
+from . import subprocess_timeout
+
+LOGGER = logging.getLogger('gateway_code')
+
+
+def call_cmd(command_str, out=None, timeout=30):
+    """Call a command in a subprocess."""
+    kwargs = {'args': shlex.split(command_str), 'stdout': out, 'stderr': out}
+    try:
+        return subprocess_timeout.call(timeout=timeout, **kwargs)
+    except subprocess_timeout.TimeoutExpired as exc:
+        LOGGER.error("Command '%s' timeout: %s", command_str, exc)
+        return 1

--- a/gateway_code/utils/tests/avrdude_test.py
+++ b/gateway_code/utils/tests/avrdude_test.py
@@ -28,7 +28,6 @@
 # pylint: disable=maybe-no-member
 # pylint: disable=unused-argument
 
-import time
 import os.path
 import unittest
 
@@ -59,37 +58,6 @@ class TestsMethods(unittest.TestCase):
     def test_invalid_firmware_path(self):
         ret = self.avr.flash('/invalid/path')
         self.assertNotEqual(0, ret)
-
-
-class TestsCall(unittest.TestCase):
-    """ Tests avrdude call timeout """
-    def setUp(self):
-        self.timeout = 5
-        self.avr = avrdude.AvrDude(NodeLeonardo.AVRDUDE_CONF,
-                                   timeout=self.timeout)
-        self.avr._avrdude_args = mock.Mock()
-
-    def test_timeout_call(self):
-        """Test timeout reached."""
-        self.avr._avrdude_args.return_value = {'args': ['sleep', '10']}
-        t_0 = time.time()
-        ret = self.avr._call_cmd('sleep')
-        t_end = time.time()
-
-        # Not to much more
-        self.assertLess(t_end - t_0, self.timeout + 1)
-        self.assertNotEqual(ret, 0)
-
-    def test_no_timeout(self):
-        """Test timeout not reached."""
-        self.avr._avrdude_args.return_value = {'args': ['sleep', '1']}
-        t_0 = time.time()
-        ret = self.avr._call_cmd('sleep')
-        t_end = time.time()
-
-        # Strictly lower here
-        self.assertLess(t_end - t_0, self.timeout - 1)
-        self.assertEqual(ret, 0)
 
 
 @mock.patch('serial.Serial')

--- a/gateway_code/utils/tests/cc2538_test.py
+++ b/gateway_code/utils/tests/cc2538_test.py
@@ -21,7 +21,6 @@
 """" some tests for the CC2538 wrapper"""
 
 import os
-import time
 import unittest
 
 import mock
@@ -78,36 +77,3 @@ class TestsCC2538Methods(unittest.TestCase):
         """Test flash an invalid firmware return a non zero value."""
         ret = self.cc2538.flash('/invalid/path')
         assert ret > 0
-
-
-class TestsCC2538Call(unittest.TestCase):
-    # pylint:disable=protected-access
-    """ Tests cc2538-bsl call timeout """
-    def setUp(self):
-        self.timeout = 5
-        self.cc2538 = cc2538.CC2538({'port': NodeFirefly.TTY,
-                                     'baudrate': NodeFirefly.BAUDRATE},
-                                    timeout=self.timeout)
-        self.cc2538._cc2538_args = mock.Mock()
-
-    def test_timeout_call(self):
-        """Test timeout reached."""
-        self.cc2538._cc2538_args.return_value = {'args': ['sleep', '10']}
-        t_0 = time.time()
-        ret = self.cc2538._call_cmd('sleep')
-        t_end = time.time()
-
-        # Not to much more
-        self.assertLess(t_end - t_0, self.timeout + 1)
-        self.assertNotEqual(ret, 0)
-
-    def test_no_timeout(self):
-        """Test timeout not reached."""
-        self.cc2538._cc2538_args.return_value = {'args': ['sleep', '1']}
-        t_0 = time.time()
-        ret = self.cc2538._call_cmd('sleep')
-        t_end = time.time()
-
-        # Strictly lower here
-        self.assertLess(t_end - t_0, self.timeout - 1)
-        self.assertEqual(ret, 0)

--- a/gateway_code/utils/tests/edbg_test.py
+++ b/gateway_code/utils/tests/edbg_test.py
@@ -27,7 +27,6 @@
 # pylint: disable=maybe-no-member
 # pylint: disable=unused-argument
 
-import time
 import unittest
 
 import mock
@@ -40,7 +39,8 @@ class TestsMethods(unittest.TestCase):
     """Tests edbg methods."""
 
     def setUp(self):
-        self.edbg = edbg.Edbg()
+        self.edbg = edbg.Edbg(timeout=10)
+        assert self.edbg.timeout == 10
 
     @mock.patch('gateway_code.utils.subprocess_timeout.call')
     def test_flash(self, call_mock):
@@ -57,33 +57,3 @@ class TestsMethods(unittest.TestCase):
     def test_invalid_firmware_path(self):
         ret = self.edbg.flash('/invalid/path')
         self.assertNotEqual(0, ret)
-
-
-class TestsCall(unittest.TestCase):
-    """ Tests edbg call timeout """
-    def setUp(self):
-        self.timeout = 5
-        self.edbg = edbg.Edbg(timeout=self.timeout)
-        self.edbg._edbg_args = mock.Mock()
-
-    def test_timeout_call(self):
-        """Test timeout reached."""
-        self.edbg._edbg_args.return_value = {'args': ['sleep', '10']}
-        t_0 = time.time()
-        ret = self.edbg._call_cmd('sleep')
-        t_end = time.time()
-
-        # Not to much more
-        self.assertLess(t_end - t_0, self.timeout + 1)
-        self.assertNotEqual(ret, 0)
-
-    def test_no_timeout(self):
-        """Test timeout not reached."""
-        self.edbg._edbg_args.return_value = {'args': ['sleep', '1']}
-        t_0 = time.time()
-        ret = self.edbg._call_cmd('sleep')
-        t_end = time.time()
-
-        # Strictly lower here
-        self.assertLess(t_end - t_0, self.timeout - 1)
-        self.assertEqual(ret, 0)

--- a/gateway_code/utils/tests/helpers_test.py
+++ b/gateway_code/utils/tests/helpers_test.py
@@ -1,0 +1,50 @@
+# -*- coding:utf-8 -*-
+
+# This file is a part of IoT-LAB gateway_code
+# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Contributor(s) : see AUTHORS file
+#
+# This software is governed by the CeCILL license under French law
+# and abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# http://www.cecill.info.
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+
+"""Utils helpers test module."""
+
+import time
+
+from .. import helpers
+
+
+def test_timeout_call():
+    """Test timeout reached."""
+    timeout = 5
+    t_0 = time.time()
+    ret = helpers.call_cmd('sleep 10', timeout=timeout)
+    t_end = time.time()
+
+    # Not to much more
+    assert t_end - t_0 < timeout + 1
+    assert ret != 0
+
+
+def test_no_timeout():
+    """Test timeout not reached."""
+    timeout = 5
+    t_0 = time.time()
+    ret = helpers.call_cmd('sleep 1', timeout=timeout)
+    t_end = time.time()
+
+    # Strictly lower here
+    assert t_end - t_0 < timeout + 1
+    assert ret == 0

--- a/gateway_code/utils/tests/openocd_test.py
+++ b/gateway_code/utils/tests/openocd_test.py
@@ -27,7 +27,6 @@
 # serial mock note correctly detected
 # pylint: disable=maybe-no-member
 
-import time
 import unittest
 import mock
 
@@ -101,36 +100,6 @@ class TestsMethods(unittest.TestCase):
         self.ocd.debug_start()
         ret = self.ocd.debug_stop()
         self.assertEqual(ret, 1)
-
-
-class TestsCall(unittest.TestCase):
-    """ Tests openocd call timeout """
-    def setUp(self):
-        self.timeout = 5
-        self.ocd = openocd.OpenOCD.from_node(NodeM3, timeout=self.timeout)
-        self.ocd._openocd_args = mock.Mock()
-
-    def test_timeout_call(self):
-        """Test timeout reached."""
-        self.ocd._openocd_args.return_value = {'args': ['sleep', '10']}
-        t_0 = time.time()
-        ret = self.ocd._call_cmd('sleep')
-        t_end = time.time()
-
-        # Not to much more
-        self.assertLess(t_end - t_0, self.timeout + 1)
-        self.assertNotEqual(ret, 0)
-
-    def test_no_timeout(self):
-        """Test timeout not reached."""
-        self.ocd._openocd_args.return_value = {'args': ['sleep', '1']}
-        t_0 = time.time()
-        ret = self.ocd._call_cmd('sleep')
-        t_end = time.time()
-
-        # Strictly lower here
-        self.assertLess(t_end - t_0, self.timeout - 1)
-        self.assertEqual(ret, 0)
 
 
 class TestsFlashInvalidPaths(unittest.TestCase):


### PR DESCRIPTION
The idea is the same as #89 but without introducing a new parent class, just moving the initial method as a shared function in a separate module.

Although I left the private `_call_cmd` in each flasher classes and this could still be factorized in a parent class, I prefer the current approach: it's simpler and it keeps the same features with timeout and how output is handled.

With this PR I'll also be able to reuse the `helpers.call_cmd` in #94.