### PR TITLE
serial_redirection cli: catch SIGTERM signal

### DIFF
--- a/gateway_code/utils/cli/serial_redirection.py
+++ b/gateway_code/utils/cli/serial_redirection.py
@@ -34,9 +34,17 @@ def _get_node(board_cfg):
     return board_cfg.board_class()
 
 
+def _handle_signal(signum, frame):
+    # pylint:disable=unused-argument
+    raise KeyboardInterrupt()
+
+
 @log_to_stderr
 def main():
     """ serial_redirection cli main function """
+    # Catch SIGTERM signal sending by start-stop-daemon
+    # init script
+    signal.signal(signal.SIGTERM, _handle_signal)
     board_cfg = board_config.BoardConfig()
     node = _get_node(board_cfg)
     try:

--- a/gateway_code/utils/tests/cli_serial_redirection_test.py
+++ b/gateway_code/utils/tests/cli_serial_redirection_test.py
@@ -22,6 +22,10 @@
 
 """ test serial_redirection module """
 
+import os
+import time
+import threading
+import signal
 import unittest
 import mock
 
@@ -65,3 +69,21 @@ class TestMain(unittest.TestCase):
         with mock.patch('sys.argv', args):
             serial_redirection.main()
             self.assertTrue(m_pause.called)
+
+    @mock.patch(utils.READ_CONFIG, utils.read_config_mock('m3'))
+    def test_signal_handling(self):
+        # pylint: disable=no-self-use
+        """ Test signal handling """
+        pid = os.getpid()
+
+        def trigger_signal():
+            """ trigger sigterm signal """
+            time.sleep(2)
+            os.kill(pid, signal.SIGTERM)
+
+        thread = threading.Thread(target=trigger_signal)
+        thread.daemon = True
+        thread.start()
+        args = ['serial_redirection.py']
+        with mock.patch('sys.argv', args):
+            serial_redirection.main()


### PR DESCRIPTION
On the Linux open nodes we should launch serial redirection with an initd script (eg. start-stop-daemon) which use now gateway code cli script. Thus to terminate correctly the daemon process we catch SIGTERM signal and raise a keyboard interrupt exception.