### PR TITLE
add basic support for pycom open nodes (Micropython inside)

### DIFF
--- a/bin/rules.d/pycom.rules
+++ b/bin/rules.d/pycom.rules
@@ -1,3 +1,9 @@
 # open nodes TTY
-SUBSYSTEM=="tty", SUBSYSTEMS=="usb", ENV{ID_USB_INTERFACE_NUM}=="00", SYMLINK+="iotlab/ttyON_PYCOM"
-SUBSYSTEM=="usb", ATTR{idProduct}=="6015", ATTR{idVendor}=="0403", MODE="0664", GROUP="dialout"
+
+# pytrack
+KERNEL=="ttyACM*", SUBSYSTEM=="tty", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="f014", SUBSYSTEMS=="usb", SYMLINK+="iotlab/ttyON_PYCOM"
+SUBSYSTEM=="usb", ATTR{idProduct}=="04d8", ATTR{idVendor}=="f014", MODE="0664", GROUP="dialout"
+
+# pysense
+KERNEL=="ttyACM*", SUBSYSTEM=="tty", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="f012", SUBSYSTEMS=="usb", SYMLINK+="iotlab/ttyON_PYCOM"
+SUBSYSTEM=="usb", ATTR{idProduct}=="04d8", ATTR{idVendor}=="f012", MODE="0664", GROUP="dialout"

--- a/bin/rules.d/pycom.rules
+++ b/bin/rules.d/pycom.rules
@@ -1,0 +1,3 @@
+# open nodes TTY
+SUBSYSTEM=="tty", SUBSYSTEMS=="usb", ENV{ID_USB_INTERFACE_NUM}=="00", SYMLINK+="iotlab/ttyON_PYCOM"
+SUBSYSTEM=="usb", ATTR{idProduct}=="6015", ATTR{idVendor}=="0403", MODE="0664", GROUP="dialout"

--- a/gateway_code/gateway_manager.py
+++ b/gateway_code/gateway_manager.py
@@ -154,14 +154,15 @@ class GatewayManager(object):  # pylint:disable=too-many-instance-attributes
         # Init ControlNode
         ret_val += self.control_node.start(self.exp_id, self.exp_files)
 
-        # Trigger power-cycle with Pycom boards to ensure REPL is correctly
+        # with Pycom boards, trigger 2 power-cycle to ensure REPL is correctly
         # started
         if self.open_node.TYPE == 'pycom':
-            LOGGER.debug("Power cycle %s board", self.open_node.TYPE)
-            ret_val += self.control_node.open_stop()
-            ret_val += wait_no_tty(self.open_node.TTY, timeout=10)
-            ret_val += self.control_node.open_start()
-            ret_val += wait_tty(self.open_node.TTY, LOGGER, timeout=10)
+            for _ in range(2):
+                LOGGER.debug("Power cycle %s board", self.open_node.TYPE)
+                ret_val += self.control_node.open_stop()
+                ret_val += wait_no_tty(self.open_node.TTY, timeout=10)
+                ret_val += self.control_node.open_start()
+                ret_val += wait_tty(self.open_node.TTY, LOGGER, timeout=10)
         # Configure Open Node
         ret_val += self.open_node.setup(firmware_path)
         # Configure experiment and monitoring on ControlNode

--- a/gateway_code/gateway_manager.py
+++ b/gateway_code/gateway_manager.py
@@ -153,6 +153,15 @@ class GatewayManager(object):  # pylint:disable=too-many-instance-attributes
 
         # Init ControlNode
         ret_val += self.control_node.start(self.exp_id, self.exp_files)
+
+        # Trigger several power-cycle with Pycom boards to ensure REPL
+        # starts correctly
+        if self.open_node.TYPE == 'pycom':
+            LOGGER.debug("Power cycle %s board", self.open_node.TYPE)
+            for _ in range(3):
+                ret_val += self.control_node.open_stop()
+                time.sleep(2)
+                ret_val += self.control_node.open_start()
         # Configure Open Node
         ret_val += self.open_node.setup(firmware_path)
         # Configure experiment and monitoring on ControlNode

--- a/gateway_code/open_nodes/node_pycom.py
+++ b/gateway_code/open_nodes/node_pycom.py
@@ -39,8 +39,9 @@ PYCOM_FLASH_ERASE_SEQUENCE = (
     b"import os\r\n",
     b"os.mkfs('/flash')\r\n",  # Erase the flash
 )
-PYCOM_SOFT_RESET_SEQUENCE = (
-    b"\x04\r\n",
+PYCOM_RESET_SEQUENCE = (
+    b"import machine\r\n",
+    b"machine.reset()\r\n",
 )
 
 
@@ -96,5 +97,5 @@ class NodePycom(NodeNoBase):
 
     @logger_call("Node Pycom: reset node")
     def reset(self):  # pylint:disable=no-self-use
-        """Software reset of the micropython interpreter."""
-        return self._send_sequence(PYCOM_SOFT_RESET_SEQUENCE)
+        """Machine reset of the pycom node."""
+        return self._send_sequence(PYCOM_RESET_SEQUENCE)

--- a/gateway_code/open_nodes/node_pycom.py
+++ b/gateway_code/open_nodes/node_pycom.py
@@ -1,0 +1,71 @@
+# -*- coding:utf-8 -*-
+
+# This file is a part of IoT-LAB gateway_code
+# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Contributor(s) : see AUTHORS file
+#
+# This software is governed by the CeCILL license under French law
+# and abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# http://www.cecill.info.
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+
+""" Open Node Pycom experiment implementation """
+
+import logging
+import serial
+
+from gateway_code.common import logger_call
+from gateway_code.utils.serial_redirection import SerialRedirection
+from gateway_code.open_nodes.common.node_no import NodeNoBase
+
+LOGGER = logging.getLogger('gateway_code')
+
+
+class NodePycom(NodeNoBase):
+    """ Open node MicroPython implementation """
+
+    TYPE = 'pycom'
+    TTY = '/dev/iotlab/ttyON_PYCOM'
+    BAUDRATE = 115200
+
+    def __init__(self):
+        self.serial_redirection = SerialRedirection(
+            self.TTY, self.BAUDRATE, serial_opts=('echo=0', 'raw', 'crnl'))
+
+    @logger_call("Node Pycom: Setup node")
+    def setup(self, firmware_path=None):
+        """Start the custom serial redirection.
+        Access from the frontend: socat -,echo=0 tcp:<node>:20000
+        """
+        return self.serial_redirection.start()
+
+    @logger_call("Node Pycom: teardown node")
+    def teardown(self):
+        """Stop the serial redirection."""
+        return self.serial_redirection.stop()
+
+    @logger_call("Node Pycom: reset node")
+    def reset(self):  # pylint:disable=no-self-use
+        """Restart micropython interpreter."""
+        ret_val = self.serial_redirection.stop()
+        try:
+            ser = serial.Serial(self.TTY, self.BAUDRATE)
+        except serial.serialutil.SerialException:
+            LOGGER.error("No serial port found")
+            ret_val += 1
+        else:
+            ser.write(b'\x04')
+            ser.close()
+        finally:
+            ret_val += self.serial_redirection.start()
+        return ret_val

--- a/gateway_code/open_nodes/node_pycom.py
+++ b/gateway_code/open_nodes/node_pycom.py
@@ -33,9 +33,11 @@ from gateway_code.open_nodes.common.node_no import NodeNoBase
 LOGGER = logging.getLogger('gateway_code')
 PYCOM_ERASE_SEQUENCE = (
     b"\r\n",
+    b"\x03\r\n",  # Interrupt any running code
+    b"\x06\r\n",  # Perform safe boot with Ctrl + F
     b"import os\r\n",
     b"print(os.listdir('/flash'))\r\n",
-    b"os.mkfs('/flash')\r\n",
+    b"os.mkfs('/flash')\r\n",  # Erase the flash
 )
 
 

--- a/gateway_code/open_nodes/node_pycom.py
+++ b/gateway_code/open_nodes/node_pycom.py
@@ -21,11 +21,12 @@
 
 """ Open Node Pycom experiment implementation """
 
+import time
 import logging
 import serial
-import time
 
-from gateway_code.common import logger_call, wait_tty
+import gateway_code.common
+from gateway_code.common import logger_call
 from gateway_code.utils.serial_redirection import SerialRedirection
 from gateway_code.open_nodes.common.node_no import NodeNoBase
 
@@ -39,7 +40,7 @@ PYCOM_ERASE_SEQUENCE = (
 
 
 class NodePycom(NodeNoBase):
-    """ Open node MicroPython implementation """
+    """ Open node Pycom implementation """
 
     TYPE = 'pycom'
     TTY = '/dev/iotlab/ttyON_PYCOM'
@@ -62,7 +63,6 @@ class NodePycom(NodeNoBase):
                 ser.write(line)
             time.sleep(2)
             LOGGER.info(ser.read_all())
-            ser.write('\x04\r\n')
             time.sleep(1)
             ser.close()
         return 0
@@ -76,8 +76,9 @@ class NodePycom(NodeNoBase):
             ssh -L 20000:<pycom node>:20000 <login>@<site>.iot-lab.info
             socat PTY,link=/tmp/ttyS0,echo=0,crnl TCP:localhost:20000
         """
-        ret_val = wait_tty(self.TTY, LOGGER, timeout=10)
+        ret_val = gateway_code.common.wait_tty(self.TTY, LOGGER, timeout=10)
         ret_val += self._clear_flash()
+        ret_val += self.reset()
         ret_val += self.serial_redirection.start()
         return ret_val
 

--- a/gateway_code/open_nodes/tests/node_pycom_test.py
+++ b/gateway_code/open_nodes/tests/node_pycom_test.py
@@ -1,0 +1,84 @@
+# -*- coding:utf-8 -*-
+
+# This file is a part of IoT-LAB gateway_code
+# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Contributor(s) : see AUTHORS file
+#
+# This software is governed by the CeCILL license under French law
+# and abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# http://www.cecill.info.
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+
+""" gateway_code.open_nodes.node_pycom unit tests files """
+
+import serial
+from mock import patch
+
+from gateway_code.open_nodes.node_pycom import NodePycom
+
+
+@patch('gateway_code.utils.external_process.ExternalProcess.start')
+def test_setup(serial_start):
+    """Test pycom node setup."""
+    serial_start.return_value = 0
+    node = NodePycom()
+
+    assert node.setup() == 0
+    assert serial_start.call_count == 1
+
+    serial_start.call_count = 0
+    serial_start.return_value = 1
+    assert node.setup() == 1
+    assert serial_start.call_count == 1
+
+
+@patch('gateway_code.utils.external_process.ExternalProcess.stop')
+def test_teardown(serial_stop):
+    """Test pycom node teardown."""
+    serial_stop.return_value = 0
+
+    node = NodePycom()
+    assert node.teardown() == 0
+    assert serial_stop.call_count == 1
+
+    serial_stop.call_count = 0
+
+    serial_stop.return_value = 1
+    assert node.teardown() == 1
+    assert serial_stop.call_count == 1
+
+
+@patch('serial.Serial')
+@patch('gateway_code.utils.external_process.ExternalProcess.start')
+@patch('gateway_code.utils.external_process.ExternalProcess.stop')
+def test_reset(serial_stop, serial_start, ser):
+    """Test pycom node reset."""
+    serial_start.return_value = 0
+    serial_stop.return_value = 0
+
+    node = NodePycom()
+    assert node.reset() == 0
+    assert serial_start.call_count == 1
+    assert serial_stop.call_count == 1
+    assert ser.call_count == 1
+    ser.assert_called_with(node.TTY, node.BAUDRATE)
+
+    serial_start.call_count = 0
+    serial_stop.call_count = 0
+    ser.call_count = 0
+    ser.side_effect = serial.serialutil.SerialException
+
+    assert node.reset() == 1
+    assert serial_start.call_count == 1
+    assert serial_stop.call_count == 1
+    assert ser.call_count == 1

--- a/gateway_code/open_nodes/tests/node_pycom_test.py
+++ b/gateway_code/open_nodes/tests/node_pycom_test.py
@@ -21,79 +21,83 @@
 
 """ gateway_code.open_nodes.node_pycom unit tests files """
 
+import unittest
 import serial
 from mock import patch
 
 from gateway_code.open_nodes.node_pycom import NodePycom
 
 
-@patch('gateway_code.common.wait_tty')
 @patch('serial.Serial')
-@patch('gateway_code.utils.external_process.ExternalProcess.start')
-def test_setup(serial_start, ser, wait):
-    """Test pycom node setup."""
-    serial_start.return_value = 0
-    wait.return_value = 0
-    node = NodePycom()
+class TestNodePycom(unittest.TestCase):
+    """Unittest class for pycom nodes."""
 
-    assert node.setup() == 0
-    assert serial_start.call_count == 1
-    assert ser.call_count == 2
+    def setUp(self):
+        self.node = NodePycom()
+        patch('time.sleep').start()
 
-    serial_start.call_count = 0
-    ser.call_count = 0
-    serial_start.return_value = 1
-    assert node.setup() == 1
-    assert serial_start.call_count == 1
-    assert ser.call_count == 2
+    def tearDown(self):
+        patch.stopall()
 
-    serial_start.call_count = 0
-    ser.call_count = 0
-    serial_start.return_value = 0
-    ser.side_effect = serial.serialutil.SerialException
+    @patch('gateway_code.common.wait_tty')
+    @patch('gateway_code.utils.external_process.ExternalProcess.start')
+    def test_setup(self, serial_start, wait, ser):
+        """Test pycom node setup."""
+        serial_start.return_value = 0
+        wait.return_value = 0
 
-    assert node.setup() == 2
-    assert ser.call_count == 2
+        assert self.node.setup() == 0
+        assert serial_start.call_count == 1
+        assert ser.call_count == 2
 
+        serial_start.call_count = 0
+        ser.call_count = 0
+        serial_start.return_value = 1
+        assert self.node.setup() == 1
+        assert serial_start.call_count == 1
+        assert ser.call_count == 2
 
-@patch('serial.Serial')
-@patch('gateway_code.utils.external_process.ExternalProcess.stop')
-def test_teardown(serial_stop, ser):
-    """Test pycom node teardown."""
-    serial_stop.return_value = 0
+        serial_start.call_count = 0
+        ser.call_count = 0
+        serial_start.return_value = 0
+        ser.side_effect = serial.serialutil.SerialException
 
-    node = NodePycom()
-    assert node.teardown() == 0
-    assert serial_stop.call_count == 1
-    assert ser.call_count == 1
+        assert self.node.setup() == 2
+        assert ser.call_count == 2
 
-    serial_stop.call_count = 0
-    ser.call_count = 0
+    @patch('gateway_code.utils.external_process.ExternalProcess.stop')
+    def test_teardown(self, serial_stop, ser):
+        """Test pycom node teardown."""
+        serial_stop.return_value = 0
 
-    serial_stop.return_value = 1
-    assert node.teardown() == 1
-    assert serial_stop.call_count == 1
-    assert ser.call_count == 1
+        assert self.node.teardown() == 0
+        assert serial_stop.call_count == 1
+        assert ser.call_count == 1
 
-    serial_stop.call_count = 0
-    ser.call_count = 0
-    serial_stop.return_value = 0
-    ser.side_effect = serial.serialutil.SerialException
+        serial_stop.call_count = 0
+        ser.call_count = 0
 
-    assert node.teardown() == 1
-    assert ser.call_count == 1
+        serial_stop.return_value = 1
+        assert self.node.teardown() == 1
+        assert serial_stop.call_count == 1
+        assert ser.call_count == 1
 
+        serial_stop.call_count = 0
+        ser.call_count = 0
+        serial_stop.return_value = 0
+        ser.side_effect = serial.serialutil.SerialException
 
-@patch('serial.Serial')
-def test_reset(ser):
-    """Test pycom node reset."""
-    node = NodePycom()
-    assert node.reset() == 0
-    assert ser.call_count == 1
-    ser.assert_called_with(node.TTY, node.BAUDRATE)
+        assert self.node.teardown() == 1
+        assert ser.call_count == 1
 
-    ser.call_count = 0
-    ser.side_effect = serial.serialutil.SerialException
+    def test_reset(self, ser):
+        """Test pycom node reset."""
+        assert self.node.reset() == 0
+        assert ser.call_count == 1
+        ser.assert_called_with(self.node.TTY, self.node.BAUDRATE)
 
-    assert node.reset() == 1
-    assert ser.call_count == 1
+        ser.call_count = 0
+        ser.side_effect = serial.serialutil.SerialException
+
+        assert self.node.reset() == 1
+        assert ser.call_count == 1

--- a/gateway_code/open_nodes/tests/node_pycom_test.py
+++ b/gateway_code/open_nodes/tests/node_pycom_test.py
@@ -48,22 +48,22 @@ class TestNodePycom(unittest.TestCase):
 
         assert self.node.setup() == 0
         assert serial_start.call_count == 1
-        assert ser.call_count == 2
+        assert ser.call_count == 3
 
         serial_start.call_count = 0
         ser.call_count = 0
         serial_start.return_value = 1
         assert self.node.setup() == 1
         assert serial_start.call_count == 1
-        assert ser.call_count == 2
+        assert ser.call_count == 3
 
         serial_start.call_count = 0
         ser.call_count = 0
         serial_start.return_value = 0
         ser.side_effect = serial.serialutil.SerialException
 
-        assert self.node.setup() == 2
-        assert ser.call_count == 2
+        assert self.node.setup() == 3
+        assert ser.call_count == 3
 
     @patch('gateway_code.utils.external_process.ExternalProcess.stop')
     def test_teardown(self, serial_stop, ser):
@@ -72,7 +72,7 @@ class TestNodePycom(unittest.TestCase):
 
         assert self.node.teardown() == 0
         assert serial_stop.call_count == 1
-        assert ser.call_count == 1
+        assert ser.call_count == 2
 
         serial_stop.call_count = 0
         ser.call_count = 0
@@ -80,15 +80,15 @@ class TestNodePycom(unittest.TestCase):
         serial_stop.return_value = 1
         assert self.node.teardown() == 1
         assert serial_stop.call_count == 1
-        assert ser.call_count == 1
+        assert ser.call_count == 2
 
         serial_stop.call_count = 0
         ser.call_count = 0
         serial_stop.return_value = 0
         ser.side_effect = serial.serialutil.SerialException
 
-        assert self.node.teardown() == 1
-        assert ser.call_count == 1
+        assert self.node.teardown() == 2
+        assert ser.call_count == 2
 
     def test_reset(self, ser):
         """Test pycom node reset."""

--- a/gateway_code/utils/serial_redirection.py
+++ b/gateway_code/utils/serial_redirection.py
@@ -42,13 +42,14 @@ class SerialRedirection(ExternalProcess):
     """
     SOCAT = ('socat -d'
              ' TCP4-LISTEN:20000,reuseaddr'
-             ' open:{tty},b{baud},echo=0,raw')
+             ' open:{tty},b{baud},{serial_opts}')
     NAME = "serial redirection"
 
-    def __init__(self, tty, baudrate):
+    def __init__(self, tty, baudrate, serial_opts=('echo=0', 'raw')):
         self.tty = tty
-        self.process_cmd = shlex.split(self.SOCAT.format(tty=tty,
-                                                         baud=baudrate))
+        self.process_cmd = shlex.split(
+            self.SOCAT.format(tty=tty, baud=baudrate,
+                              serial_opts=','.join(serial_opts)))
 
         super(SerialRedirection, self).__init__()
 


### PR DESCRIPTION
This PR provides a POC for supporting [Pycom](https://pycom.io/) nodes in IoT-LAB:
- only the MicroPython REPL is available via the serial_redirection
- the serial_redirection is slightly adapted by this PR to allow passing extra socat options: indeed the Micropython REPL requires `crnl` which is not used with the regular serial redirection.
- flashing the underlying firmware or uploading a Python script is not possible
- basic interaction with the REPL is possible via the web terminal (no copy/paste which is annoying)
- access to the REPL is possible **from the frontend** but not using `nc`. Users have to use the following commands:
  ```
  $ stty -icanon
  $ socat -,echo=0 tcp:<pycom node>:20000
  ```
- it should be possible to access the REPL via `pymakr` (Atom extension for micropython) using ssh tunneling + socat but I haven't tried yet.

There's one node for testing in devsaclay (pycom-1). The type of pycom board is provided by the `archi` field in the resources file (`pycom:fipy`, `pycom:lopy`, etc). The one in devsaclay is a `fipy`.

![iotlab-micropython](https://user-images.githubusercontent.com/1375137/52962521-ba4cfb00-339d-11e9-8123-0a50bf65bd60.png)