### PR TITLE
open_nodes: add node_lora_gateway

### DIFF
--- a/gateway_code/open_nodes/node_lora_gateway.py
+++ b/gateway_code/open_nodes/node_lora_gateway.py
@@ -1,0 +1,94 @@
+# -*- coding:utf-8 -*-
+
+# This file is a part of IoT-LAB gateway_code
+# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Contributor(s) : see AUTHORS file
+#
+# This software is governed by the CeCILL license under French law
+# and abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# http://www.cecill.info.
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+
+""" Open Node LoRa gateway experiment implementation """
+
+import os
+import time
+import logging
+import shlex
+import subprocess
+
+from gateway_code.common import logger_call
+from gateway_code.open_nodes.common.node_no import NodeNoBase
+from gateway_code.utils.lora_gateway_bridge import LoraGatewayBridge
+from gateway_code.utils.mosquitto import Mosquitto
+
+LOGGER = logging.getLogger('gateway_code')
+LOG_DIR = '/var/log/gateway-server'
+LORA_PKT_FORWARDER_START_CMD = ('sudo '  # needs to be root to access GPIO
+                                'CFG_DIR=/var/local/config /opt/lora/start.sh')
+LORA_PKT_FORWARDER_MAX_TRIES = 50
+
+
+class NodeLoraGateway(NodeNoBase):
+    """ Open node LoRa gateway implementation """
+
+    TYPE = 'lora_gw'
+    MOSQUITTO_PORT = 1883
+
+    def __init__(self):
+        self.lora_pkt_fwd_out = open(os.devnull, 'w')
+        self._start_lora_pkt_fwd()
+        self.mosquitto = Mosquitto(self.MOSQUITTO_PORT)
+        self.lora_gateway_bridge = LoraGatewayBridge()
+
+    @staticmethod
+    def _lora_pkt_fwd_pid():
+        try:
+            return subprocess.check_output(shlex.split('pgrep lora_pkt_fwd'))
+        except subprocess.CalledProcessError:
+            return None
+
+    def _start_lora_pkt_fwd(self):
+        _pid = self._lora_pkt_fwd_pid()
+        if _pid is None:
+            LOGGER.debug("Starting lora_pkt_fwd")
+        _tries = 0
+        # Sometimes the lora_pkt_forwarder fails to start so try multiple
+        # times.
+        while _pid is None and _tries <= LORA_PKT_FORWARDER_MAX_TRIES:
+            subprocess.Popen(shlex.split(LORA_PKT_FORWARDER_START_CMD),
+                             stdout=self.lora_pkt_fwd_out,
+                             stderr=self.lora_pkt_fwd_out)
+            time.sleep(2)
+            _pid = self._lora_pkt_fwd_pid()
+            if _pid is None:
+                LOGGER.debug("Restarting lora_pkt_fwd")
+                _tries += 1
+        LOGGER.debug("lora_pkt_forwarder started")
+
+    def __del__(self):
+        self.lora_pkt_fwd_out.close()
+
+    @logger_call("Node LoRa gateway: Setup node")
+    def setup(self, firmware_path=None):
+        """Start mosquitto and the gateway bridge."""
+        ret_val = self.mosquitto.start()
+        ret_val += self.lora_gateway_bridge.start()
+        return ret_val
+
+    @logger_call("Node LoRa gateway: teardown node")
+    def teardown(self):
+        """Stop the gateway bridge and mosquitto."""
+        ret_val = self.lora_gateway_bridge.stop()
+        ret_val += self.mosquitto.stop()
+        return ret_val

--- a/gateway_code/open_nodes/tests/node_lora_gateway_test.py
+++ b/gateway_code/open_nodes/tests/node_lora_gateway_test.py
@@ -1,0 +1,84 @@
+# -*- coding:utf-8 -*-
+
+# This file is a part of IoT-LAB gateway_code
+# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Contributor(s) : see AUTHORS file
+#
+# This software is governed by the CeCILL license under French law
+# and abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# http://www.cecill.info.
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+
+""" gateway_code.open_nodes.node_lora_gateway unit tests files """
+
+import subprocess
+from mock import patch
+
+from gateway_code.open_nodes.node_lora_gateway import NodeLoraGateway
+
+# pylint:disable=unused-argument
+
+
+@patch('subprocess.Popen')
+@patch('subprocess.check_output')
+@patch('gateway_code.utils.external_process.ExternalProcess.start')
+def test_setup(start, check_output, popen):
+    """Test lora_gateway node setup."""
+    check_output.return_value = 42
+    start.return_value = 0
+    node = NodeLoraGateway()
+
+    assert node.setup() == 0
+    assert check_output.call_count == 1
+    assert start.call_count == 2
+
+    start.call_count = 0
+    check_output.call_count = 0
+
+    start.return_value = 1
+    assert node.setup() == 2
+    assert check_output.call_count == 0
+    assert start.call_count == 2
+
+
+@patch('gateway_code.open_nodes.node_lora_gateway.'
+       'LORA_PKT_FORWARDER_MAX_TRIES', 1)
+@patch('time.sleep')
+@patch('subprocess.Popen')
+@patch('subprocess.check_output')
+def test_setup_no_pkt_forwarder(check, popen, sleep):
+    """Smoke test when no pkt forwarder is running."""
+    check.side_effect = subprocess.CalledProcessError("test", "test")
+    NodeLoraGateway()
+
+
+@patch('subprocess.Popen')
+@patch('subprocess.check_output')
+@patch('gateway_code.utils.external_process.ExternalProcess.stop')
+def test_teardown(stop, check_output, popen):
+    """Test lora_gateway node teardown."""
+    check_output.return_value = 42
+    stop.return_value = 0
+
+    node = NodeLoraGateway()
+    assert node.teardown() == 0
+    assert check_output.call_count == 1
+    assert stop.call_count == 2
+
+    check_output.call_count = 0
+    stop.call_count = 0
+
+    stop.return_value = 1
+    assert node.teardown() == 2
+    assert check_output.call_count == 0
+    assert stop.call_count == 2

--- a/gateway_code/open_nodes/tests/open_nodes_test.py
+++ b/gateway_code/open_nodes/tests/open_nodes_test.py
@@ -47,8 +47,12 @@ def test_open_node_class_errors():
         open_node_class('unknown')
 
 
-def test_nodes_classes():
+@patch('subprocess.check_output')
+def test_nodes_classes(check_output):
     """Test loading all implemented open nodes implementation."""
+    # node_lora_gateway starts the lora_pkt_forwarder during initialization
+    # so we need to mock the process pid check.
+    check_output.return_value = 42
     for node in all_open_nodes_types():
         # No exception
         print(node)

--- a/gateway_code/utils/lora_gateway_bridge.py
+++ b/gateway_code/utils/lora_gateway_bridge.py
@@ -1,0 +1,62 @@
+# -*- coding:utf-8 -*-
+
+# This file is a part of IoT-LAB gateway_code
+# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Contributor(s) : see AUTHORS file
+#
+# This software is governed by the CeCILL license under French law
+# and abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# http://www.cecill.info.
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+
+
+"""Module managing the lora gateway bridge tool."""
+
+import os
+import shlex
+
+import logging
+
+from .external_process import ExternalProcess
+
+LOGGER = logging.getLogger('gateway_code')
+LOG_DIR = '/var/log/gateway-server'
+CFG_DIR = '/var/local/config'
+LORA_GATEWAY_BRIDGE_DIR = '/opt/lora-gateway-bridge'
+LORA_GATEWAY_BRIDGE = os.path.join(LORA_GATEWAY_BRIDGE_DIR,
+                                   'lora-gateway-bridge')
+LORA_GATEWAY_BRIDGE_CMD = '{bridge} -c {cfg_file}'
+
+
+class LoraGatewayBridge(ExternalProcess):
+    """Class providing node Lora gateway bridge tool
+
+    It's implemented as a stoppable thread running the pkt_forwarder in a loop.
+    """
+    NAME = "lora_gateway_bridge"
+
+    def __init__(self):
+        _bridge_conf_filename = 'lora-gateway-bridge.toml'
+        _bridge_cfg = os.path.join(LORA_GATEWAY_BRIDGE_DIR,
+                                   _bridge_conf_filename)
+        if os.path.isfile(os.path.join(CFG_DIR, _bridge_conf_filename)):
+            _bridge_cfg = os.path.join(CFG_DIR, _bridge_conf_filename)
+        self.process_cmd = shlex.split(LORA_GATEWAY_BRIDGE_CMD.format(
+            bridge=LORA_GATEWAY_BRIDGE, cfg_file=_bridge_cfg))
+        super(LoraGatewayBridge, self).__init__()
+
+    def check_error(self, retcode):
+        """Print debug message and check error."""
+        if retcode and self._run:
+            LOGGER.warning('%s error or restarted', self.NAME)
+        return retcode

--- a/gateway_code/utils/mosquitto.py
+++ b/gateway_code/utils/mosquitto.py
@@ -1,0 +1,52 @@
+# -*- coding:utf-8 -*-
+
+# This file is a part of IoT-LAB gateway_code
+# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Contributor(s) : see AUTHORS file
+#
+# This software is governed by the CeCILL license under French law
+# and abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# http://www.cecill.info.
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+
+
+"""Module managing the open node mosquitto broker."""
+
+import shlex
+
+import logging
+
+from .external_process import ExternalProcess
+
+LOGGER = logging.getLogger('gateway_code')
+
+LOG_DIR = '/var/log/gateway-server'
+MOSQUITTO_CMD = '/usr/sbin/mosquitto -v -p {port}'
+
+
+class Mosquitto(ExternalProcess):
+    """ Class providing node mosquitto broker
+
+    It's implemented as a stoppable thread running mosquitto in a loop.
+    """
+    NAME = "mosquitto"
+
+    def __init__(self, port):
+        self.process_cmd = shlex.split(MOSQUITTO_CMD.format(port=port))
+        super(Mosquitto, self).__init__()
+
+    def check_error(self, retcode):
+        """Print debug message and check error."""
+        if retcode and self._run:
+            LOGGER.warning('%s error or restarted', self.NAME)
+        return retcode


### PR DESCRIPTION
- provide external processes wrapping mosquitto and lora_gateway_bridge tools + tests
- provide node_lora_gateway as new open_node

The LoRa gateway uses the IMST iC880a lora multi-channel shield, plugged on a RPI3 gateway via an adaption board (see [here](https://github.com/ttn-zh/ic880a-gateway/wiki) for hardware details).
Since the lora_pkt_forwarder requires root privileges to be run (access low level GPIOs and SPI), it's started when instanciating the open_node, e.g. once at the beginning of the gateway code.
In the end, the open_node is just starting the lora_gateway_bridge and a mosquitto server for each experiment.

Users can then retrieve all lorawan packets catched by the lora radio using the MQTT protocol (on port 1883 without authentication or encryption):

```
mosquitto_sub -h <gateway-netaddress> -t "gateway/+/+" -v
```