### PR TITLE
open_node/st-lrwan1: enable dual bank support with openocd

### DIFF
--- a/gateway_code/open_nodes/node_st_lrwan1.py
+++ b/gateway_code/open_nodes/node_st_lrwan1.py
@@ -31,5 +31,6 @@ class NodeStLrwan1(NodeStLinkBase):
     TYPE = 'st_lrwan1'
     ROM_START_ADDR = 0x08000000
     OPENOCD_CFG_FILE = static_path('iot-lab-st-lrwan1.cfg')
+    OPENOCD_PATH = '/opt/openocd-dev/bin/openocd'
     FW_IDLE = static_path('st-lrwan1_idle.elf')
     FW_AUTOTEST = static_path('st-lrwan1_autotest.elf')

--- a/gateway_code/static/iot-lab-st-lrwan1.cfg
+++ b/gateway_code/static/iot-lab-st-lrwan1.cfg
@@ -1,5 +1,5 @@
 source [find interface/stlink-v2-1.cfg]
 transport select hla_swd
-source [find target/stm32l0.cfg]
+source [find target/stm32l0_dual_bank.cfg]
 reset_config srst_only connect_assert_srst
 $_TARGETNAME configure -rtos auto


### PR DESCRIPTION
This boards provide a dual bank 192kB flash memory and the current OpenOCD configuration only works with single bank which means only 96kB of flash is available.

This PR is based on #112 because I fear there will be conflicts with the ROM_START_ADDR attribute introduced there.