### PR TITLE
open_nodes: use system wide openocd version 0.10.0

### DIFF
--- a/gateway_code/open_nodes/common/node_openocd.py
+++ b/gateway_code/open_nodes/common/node_openocd.py
@@ -40,7 +40,7 @@ class NodeOpenOCDBase(OpenNodeBase):
 
     ELF_TARGET = ('ELFCLASS32', 'EM_ARM')
     OPENOCD_CLASS = OpenOCD
-    OPENOCD_PATH = '/opt/openocd-0.10.0/bin/openocd'
+    OPENOCD_PATH = 'openocd'
 
     AUTOTEST_AVAILABLE = [
         'echo', 'get_time',  # mandatory

--- a/gateway_code/open_nodes/node_nucleo_f070rb.py
+++ b/gateway_code/open_nodes/node_nucleo_f070rb.py
@@ -30,6 +30,5 @@ class NodeNucleof070RB(NodeStLinkBase):
 
     TYPE = 'nucleo_f070rb'
     OPENOCD_CFG_FILE = static_path('iot-lab-nucleo-f070rb.cfg')
-    OPENOCD_PATH = '/opt/openocd-0.10.0/bin/openocd'
     FW_IDLE = static_path('nucleo-f070rb_idle.elf')
     FW_AUTOTEST = static_path('nucleo-f070rb_autotest.elf')

--- a/gateway_code/open_nodes/node_st_iotnode.py
+++ b/gateway_code/open_nodes/node_st_iotnode.py
@@ -30,6 +30,5 @@ class NodeStIotnode(NodeStLinkBase):
 
     TYPE = 'st_iotnode'
     OPENOCD_CFG_FILE = static_path('iot-lab-st-iotnode.cfg')
-    OPENOCD_PATH = '/opt/openocd-0.10.0/bin/openocd'
     FW_IDLE = static_path('st-iotnode_idle.elf')
     FW_AUTOTEST = static_path('st-iotnode_autotest.elf')


### PR DESCRIPTION
Removes the use of custom path for openocd 0.10.0 which will be available system wide, once https://github.com/iot-lab/iot-lab-yocto/pull/35 is merged.