### PR TITLE
Documentation changes

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -131,7 +131,7 @@ the class used by the gateway will be
 In many cases, it's not difficult to add a new node based on a node that is close to it
 or to a common type of node. Nodes using openOCD to connect to it can 
 derive from `gateway_code.open_nodes.common.node_openocd.NodeOpenOCDBase`, 
-mostly just providing a `OPENOCD_CFG_FILE` attributes is enough. 
+mostly just providing a `OPENOCD_CFG_FILE` attribute is enough. 
 
 We recommend you look at all the examples of open nodes supported by the platform for
 inspiration: [gateway_code/open_nodes](gateway_code/open_nodes)
@@ -238,29 +238,38 @@ on [ci-firmwares](https://github.com/iot-lab/ci-firmwares)
 Testing your implementation
 ===========================
 
-We've provided Dockerfiles with all the dependencies and a Makefile
-for you to build and use them. (if using MacOS, see Appendix below)
-
-Using Docker
-------------
-
-If you want to run tests with the Docker containers, first build the Docker images:
-
-    make build-docker-image-test
+For unit-testing and integration-testing it's recommended to use the 
+provided Docker images, but you can test without Docker if you want.
 
 ### Unit tests
 
 The purpose of unit tests is to verify your Python code,
 independently from connections to a physical board.
 
-To run the unit tests with the provided Docker image, just run:
-
-    make test
-
 ### Integration tests
 
 The purpose of integration tests is to verify that your flashing tool
 and firmwares behave as expected when called by the gateway code.
+
+Setup udev-rules
+----------------
+
+The udev-rules must be setup on the host computer in order to map the custom iotlab TTY in the docker container:
+
+    make setup-udev-rules
+
+Using Docker
+------------
+
+You should read [DOCKER.md](DOCKER.md) for prerequisites
+
+Build the testing image:
+
+    make build-docker-image-test
+
+To run the unit tests with the provided Docker image, just run:
+
+    make test
 
 To run the integration tests inside a docker container, just run:
 
@@ -277,22 +286,13 @@ for running the tests.
 >
 >     pip install tox
 
-### Unit tests
-
-Run:
+To run the unit tests:
 
     make local-test
 
-### Integration tests
-
-Run:
+To run the integration tests:
 
     make BOARD={node_name} local-integration-test
-
-This will create a temporary config directory,
-containing the board_type and hostname,
-equivalent to the `/var/local/config` in the IoT-LAB infrastructure,
-and run `tox -e test`
 
 Appendices
 ==========
@@ -344,7 +344,7 @@ Start Docker Toolbox with the Docker Quickstart Terminal, then do this additionn
         docker@default:~$ git clone https://www.github.com/iot-lab/iot-lab-gateway.git && cd iot-lab-gateway
         docker@default:~$ sudo cp bin/rules.d/* /etc/udev/rules.d/.
         docker@default:~$ sudo udevadm control --reload
-1. Thanks to the VirtualBox GUI or via VBoxManage command line, add a USB device filter for the device  used as Open Node.
+1. Thanks to the VirtualBox GUI or via VBoxManage command line, add a USB device filter for the device used as Open Node.
 
         $ VBoxManage list usbhost
         $ VBoxManage usbfilter add 1 --target default --name M3 --vendorid 0403 --productid 6010
@@ -355,7 +355,7 @@ Start Docker Toolbox with the Docker Quickstart Terminal, then do this additionn
 
 Build the docker image and run `docker-run` as explained above.
 
-There might be similar problems with running under Windows with certain versions of Docker for Windows, or inside a Ubuntu VM
-on a Windows host, don't hesitate to contact us if you're facing problems with the setup. The setup should be 
-similar to the above, udev rules should be on the topmost host, and devices forwarded correctly to the place
+There might be similar problems when running under Windows with certain versions of Docker for Windows, or inside a Ubuntu VM
+on a Windows host, don't hesitate to contact us if you are facing problems with the setup. The setup should be 
+similar to the above, udev rules should be set on the host, and devices forwarded correctly to the place
 where the Docker daemon can reach them correctly.

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,16 +1,23 @@
 Docker Image of iot-lab-gateway
 ===============================
 
-The included Dockerfile includes all the necessary dependencies listed in [INSTALL.md](INSTALL.md), without you having
-to install them on your host machine.
+The provided Dockerfile builds a Docker image that installs all the necessary dependencies listed in [INSTALL.md](INSTALL.md), 
+without you having to install them on the host machine. 
 
-The only prerequisite before running the image for the first time is installing udev rules on the host. The udev rules create a subdirectory /dev/iotlab
+The only prerequisite on the host before running the container for the first time is to install udev rules on the host, which is done with:
 
     python setup.py udev_rules_install
+    
+Alternatively, 
+
+    make setup-udev-rules
+    udevadm control --reload
+
+The udev rules create a subdirectory /dev/iotlab which will be populated once a supported board is plugged.
 
 For the following commands sudo might be needed depending on whether your user is in the `docker` group:
 
-To build the image :
+To build the image (need to be done only once, unless you modify the Dockerfile):
 
     make build-docker-image
 

--- a/README.md
+++ b/README.md
@@ -8,21 +8,24 @@ IoT-Lab Gateway
 This is the Python code that runs on the gateway for the FIT IoT-lab
 platform. It serves an API for starting, stopping experiments, flashing firmwares.
 
-For a description of the hardware, see a [General overview](https://www.iot-lab.info/hardware/#iot-lab-node) and [Gateway Hardware](https://github.com/iot-lab/iot-lab/wiki/Hardware_Iotlab-gateway)
-
-If you want to run this code on your own, you have two choices:
-
-* (Recommended) Using the provided Docker image
-
-    make BOARD={node_name} run
-
-    (e.g. BOARD=arduino_zero)
-
-* Installing manualy all the dependencies, you should read [INSTALL.md](INSTALL.md)
+For a description of the hardware on which this code is usually run, see a [General overview](https://www.iot-lab.info/hardware/#iot-lab-node)
+and [Gateway Hardware](https://github.com/iot-lab/iot-lab/wiki/Hardware_Iotlab-gateway). It can also be run on
+many hardware, including Raspberry Pi. 
 
 
-If you want to create support for a new custom open node, you should read [DEVELOPER.md](DEVELOPER.md)
+* If you want to run this code on your own, we recommend you use the Docker-based procedure [DOCKER.md](DOCKER.md)
+
+
+* If you want to manually install all the dependencies, you should read [INSTALL.md](INSTALL.md)
+
+
+Once the gateway API is running, it will be accessible on `localhost:8080` 
+and can be queried using curl, look at the directory `tests_utils/curl_scripts` for documented examples
+
+* If you want to add support for a new custom open node, you should read [DEVELOPER.md](DEVELOPER.md)
 
 
 This code is integrated into a Yocto image (see https://github.com/iot-lab/iot-lab-yocto)
-on which each gateway boots
+on which each gateway boots remotely. The configuration of the API (specifying what board is connected, etc)
+is done through a directory /var/local/config that is a NFS mount. Monitoring data (logs, radio & consumption monitoring)
+is written inside the /iotlab folder which is also a NFS mount

--- a/tests_utils/curl_scripts/auto_test.sh
+++ b/tests_utils/curl_scripts/auto_test.sh
@@ -1,5 +1,7 @@
 #! /bin/bash -x
 
+# start a blink autotest and radio ping pong on channel 22 with the control node
+
 if [[ "x" == "x$1" ]]
 then
         IP_ADDR=192.168.1.5

--- a/tests_utils/curl_scripts/debug_start.sh
+++ b/tests_utils/curl_scripts/debug_start.sh
@@ -1,3 +1,5 @@
 #! /bin/bash -x
 
+# start debugging the open node
+
 curl -X PUT http://localhost:8080/open/debug/start; echo

--- a/tests_utils/curl_scripts/debug_stop.sh
+++ b/tests_utils/curl_scripts/debug_stop.sh
@@ -1,3 +1,5 @@
 #! /bin/bash -x
 
+# stop debugging the open node
+
 curl -X PUT http://localhost:8080/open/debug/stop; echo

--- a/tests_utils/curl_scripts/flash_firmware.sh
+++ b/tests_utils/curl_scripts/flash_firmware.sh
@@ -1,3 +1,5 @@
 #! /bin/bash -x
 
+# tries to flash the serial_echo.elf firmware on the open node
+
 curl -X POST -H "Content-Type: multipart/form-data" http://localhost:8080/open/flash -F "firmware=@serial_echo.elf"; echo

--- a/tests_utils/curl_scripts/reset.sh
+++ b/tests_utils/curl_scripts/reset.sh
@@ -1,3 +1,5 @@
 #! /bin/bash -x
 
+# soft reset the node
+
 curl -X PUT http://localhost:8080/open/reset; echo

--- a/tests_utils/curl_scripts/start.sh
+++ b/tests_utils/curl_scripts/start.sh
@@ -1,3 +1,5 @@
 #! /bin/bash -x
 
+# start the node
+
 curl -X PUT http://localhost:8080/open/start; echo

--- a/tests_utils/curl_scripts/start_exp.sh
+++ b/tests_utils/curl_scripts/start_exp.sh
@@ -1,4 +1,6 @@
 #! /bin/bash -x
 
+# start an experiment (id 123, user named test), with the simple_idle firmware and the consumption.json monitoring profile
+
 
 curl -X POST -H "Content-Type: multipart/form-data" http://localhost:8080/exp/start/123/test -F "firmware=@simple_idle.elf" -F "profile=@consumption.json"; echo

--- a/tests_utils/curl_scripts/start_exp_autotest_fw.sh
+++ b/tests_utils/curl_scripts/start_exp_autotest_fw.sh
@@ -1,8 +1,6 @@
 #! /bin/bash -x
 
+# start an autotest experiment with fox_autotest.elf, and monitoring consumption.elf
 
-#ssh gateway 'rm   -rf /iotlab/users/clochette/.senslab/123/
- #            mkdir -p /iotlab/users/clochette/.senslab/123/consumption
-  #           mkdir -p /iotlab/users/clochette/.senslab/123/radio'
 
 curl -X POST -H "Content-Type: multipart/form-data" http://localhost:8080/exp/start/123/test -F "firmware=@/tmp/iot-lab-gateway/gateway_code/static/fox_autotest.elf" -F "profile=@consumption.json"; echo

--- a/tests_utils/curl_scripts/start_exp_fw.sh
+++ b/tests_utils/curl_scripts/start_exp_fw.sh
@@ -1,9 +1,9 @@
 #! /bin/bash -x
 
+# start an experiment (id 123, user named test), with the given firmware
+# example:
+#  ./start_exp_fw.sh <path-to-firmware.elf>
 
-#ssh gateway 'rm   -rf /iotlab/users/clochette/.senslab/123/
- #            mkdir -p /iotlab/users/clochette/.senslab/123/consumption
-  #           mkdir -p /iotlab/users/clochette/.senslab/123/radio'
 
 curl -X POST -H "Content-Type: multipart/form-data" http://localhost:8080/exp/start/123/test \
     -F "firmware=@$1" -F "profile=@consumption.json"; echo

--- a/tests_utils/curl_scripts/start_exp_fw_custom.sh
+++ b/tests_utils/curl_scripts/start_exp_fw_custom.sh
@@ -1,4 +1,8 @@
 #! /bin/bash -x
 
+# start an experiment (id 123, user named test), with the given firmware, with no monitoring
+# example:
+#  ./start_exp_fw.sh <path-to-firmware.elf>
+
 curl -X POST -H "Content-Type: multipart/form-data" http://localhost:8080/exp/start/123/test \
     -F "firmware=@$1"; echo

--- a/tests_utils/curl_scripts/stop.sh
+++ b/tests_utils/curl_scripts/stop.sh
@@ -1,3 +1,5 @@
 #! /bin/bash -x
 
+# stop the open node
+
 curl -X PUT http://localhost:8080/open/stop; echo

--- a/tests_utils/curl_scripts/stop_exp.sh
+++ b/tests_utils/curl_scripts/stop_exp.sh
@@ -1,3 +1,5 @@
 #! /bin/bash -x
 
+# stop the currently running experiment
+
 curl -X DELETE http://localhost:8080/exp/stop ; echo


### PR DESCRIPTION
After the deploy in Nantes, we identified a few pain points in the doc, I tried to address those here.
- make clearer and separate the three modes : install the dependencies then run, run-in-docker, develop a new open node
- add some info in developer.md that would have been useful to develop support for a new node (a st nucleo board in that case)