### PR TITLE
Add Python 3 compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ PORT ?= 8080
 SERIAL_PORT ?= 20000
 CONTROL_NODE_TYPE ?= no
 POSARGS ?=
+TOXENV ?=
 
 DOCKER_IMAGE ?= fitiotlab/iot-lab-gateway
 DOCKER_IMAGE_TEST ?= $(DOCKER_IMAGE)-tests
@@ -34,6 +35,7 @@ test:
 	docker run -ti --rm \
 		-v $(PWD):/shared \
 		-e LOCAL_USER_ID=`id -u $(USER)` \
+		-e TOXENV=$(TOXENV) \
 		$(DOCKER_IMAGE_TEST) tox $(POSARGS)
 
 integration-test: setup-cfg-dir

--- a/control_node_serial/examples/send_commands.py
+++ b/control_node_serial/examples/send_commands.py
@@ -25,20 +25,20 @@ def main(command_file_path):
                 time.sleep(1)
                 continue
 
-            print >> sys.stderr, stripped_line
+            sys.stderr.write(stripped_line + '\n')
             # comments
             if stripped_line[0] == '#':
                 continue
 
-            print stripped_line
+            print(stripped_line)
             # sleep after each line, blank lines act as delay
             time.sleep(1)
 
 
 if __name__ == '__main__':
-    print >> sys.stderr, ' '.join(sys.argv)
+    sys.stderr.write(' '.join(sys.argv) + '\n')
     if len(sys.argv) != 2:
-        print >> sys.stderr, "Usage: %s <command_file>" % sys.argv[0]
+        sys.stderr.write("Usage: %s <command_file>\n" % sys.argv[0])
         exit(1)
 
     command_file_path = sys.argv[1]

--- a/gateway_code/autotest/autotest.py
+++ b/gateway_code/autotest/autotest.py
@@ -79,15 +79,8 @@ def autotest_control_node_checker(*required):
 
 
 class FatalError(Exception):
-
     """ FatalError during tests """
-
-    def __init__(self, value):
-        super(FatalError, self).__init__()
-        self.value = value
-
-    def __str__(self):
-        return repr(self.value)
+    pass
 
 
 def tst_ok(bool_value):

--- a/gateway_code/autotest/tests/autotest_test.py
+++ b/gateway_code/autotest/tests/autotest_test.py
@@ -119,9 +119,9 @@ class TestProtocolGPS(unittest.TestCase):
             cmd = args[0]
             if cmd == 'test_pps_start':
                 return (0, ['ACK', 'test_pps_start'])
-            elif cmd == 'test_pps_stop':
+            if cmd == 'test_pps_stop':
                 return (0, ['ACK', 'test_pps_stop'])
-            elif cmd == 'test_pps_get':
+            if cmd == 'test_pps_get':
                 return pps_get_values.pop(0)
 
             raise ValueError('Unknown command %r' % cmd)

--- a/gateway_code/autotest/tests/autotest_test.py
+++ b/gateway_code/autotest/tests/autotest_test.py
@@ -230,13 +230,7 @@ class TestAutoTestsErrorCases(unittest.TestCase):
     def test_assert(self, check):
         ret = 1
         check.return_value = ret
-        with pytest.raises(autotest.FatalError) as exc:
+        with pytest.raises(autotest.FatalError) as exc_info:
             assert self.g_v._assert(1, "noop", "err_log", "err_msg") == ret
-        assert "err_msg" in str(exc)
-
-
-class TestAutotestFatalError(unittest.TestCase):
-
-    def test_fatal_error(self):
-        error = autotest.FatalError("error_value")
-        self.assertEqual("'error_value'", str(error))
+        assert exc_info.type is autotest.FatalError
+        assert "err_msg" in str(exc_info.value)

--- a/gateway_code/common.py
+++ b/gateway_code/common.py
@@ -26,6 +26,14 @@
 import os
 import time
 import errno
+
+try:
+    # pylint: disable=unused-import
+    import Queue as queue  # noqa
+except ImportError:
+    # pylint: disable=unused-import
+    import queue  # noqa
+
 # http://code.activestate.com/recipes/\
 #     577105-synchronization-decorator-for-class-methods/
 # About `functools.wraps` http://stackoverflow.com/a/309000/395687
@@ -64,21 +72,20 @@ def logger_call(msg, log_lvl='info', err_lvl='warning'):
     return _wrap
 
 
-def empty_queue(queue):
+def empty_queue(my_queue):
     """ Remove all items in Queue
 
-    >>> import queue
-    >>> queue = queue.Queue(0)
-    >>> _ = [queue.put(i) for i in range(0, 10)]
+    >>> my_queue = queue.Queue(0)
+    >>> _ = [my_queue.put(i) for i in range(0, 10)]
 
-    >>> queue.empty()
+    >>> my_queue.empty()
     False
-    >>> empty_queue(queue)
-    >>> queue.empty()
+    >>> empty_queue(my_queue)
+    >>> my_queue.empty()
     True
     """
-    while not queue.empty():
-        queue.get_nowait()
+    while not my_queue.empty():
+        my_queue.get_nowait()
 
 
 def wait_cond(timeout, value, fct, *args, **kwargs):

--- a/gateway_code/common.py
+++ b/gateway_code/common.py
@@ -163,7 +163,7 @@ def deepgetattr(obj, attr):
 
     http://pingfive.typepad.com/blog/2010/04/deep-getattr-python-function.html
     """
-    return reduce(getattr, attr.split('.'), obj)
+    return functools.reduce(getattr, attr.split('.'), obj)
 
 
 def object_attr_has(obj, features_attr, required_list):

--- a/gateway_code/common.py
+++ b/gateway_code/common.py
@@ -67,8 +67,8 @@ def logger_call(msg, log_lvl='info', err_lvl='warning'):
 def empty_queue(queue):
     """ Remove all items in Queue
 
-    >>> import Queue
-    >>> queue = Queue.Queue(0)
+    >>> import queue
+    >>> queue = queue.Queue(0)
     >>> _ = [queue.put(i) for i in range(0, 10)]
 
     >>> queue.empty()

--- a/gateway_code/common.py
+++ b/gateway_code/common.py
@@ -24,6 +24,7 @@
 """ Common functions of the module """
 
 import os
+import sys
 import time
 import errno
 
@@ -41,6 +42,13 @@ import functools
 
 import logging
 LOGGER = logging.getLogger('gateway_code')
+
+
+if int(sys.version[0]) < 3:
+    # pylint: disable=undefined-variable
+    _basestring = basestring  # noqa
+else:
+    _basestring = str
 
 
 def logger_call(msg, log_lvl='info', err_lvl='warning'):
@@ -236,7 +244,7 @@ def booleanize(value):
     if isinstance(value, bool):
         return value
 
-    if isinstance(value, basestring):
+    if isinstance(value, _basestring):
         value = value.lower()
 
     if value in ('y', 'yes', 't', 'true', 'on', '1', 1):

--- a/gateway_code/common.py
+++ b/gateway_code/common.py
@@ -249,7 +249,8 @@ def booleanize(value):
 
     if value in ('y', 'yes', 't', 'true', 'on', '1', 1):
         return True
-    elif value in ('n', 'no', 'f', 'false', 'off', '0', 0, None):
+
+    if value in ('n', 'no', 'f', 'false', 'off', '0', 0, None):
         return False
-    else:
-        raise ValueError("invalid value '{}'".format(value))
+
+    raise ValueError("invalid value '{}'".format(value))

--- a/gateway_code/control_nodes/cn_iotlab/cn_interface.py
+++ b/gateway_code/control_nodes/cn_iotlab/cn_interface.py
@@ -26,7 +26,7 @@ Manage sending commands and receiving messages
 """
 
 from subprocess import PIPE
-import Queue
+import queue
 import threading
 import logging
 from tempfile import NamedTemporaryFile
@@ -68,11 +68,11 @@ class ControlNodeSerial(object):  # pylint:disable=too-many-instance-attributes
         self.tty = tty
         self.process = None
         self.reader_thread = None
-        self.msgs = Queue.Queue(1)
+        self.msgs = queue.Queue(1)
         self.measures_debug = None
 
         self._send_mutex = threading.Semaphore(1)
-        self._wait_ready = Queue.Queue(1)
+        self._wait_ready = queue.Queue(1)
         self._oml_cfg_file = None
 
         # cleanup in case of error
@@ -197,7 +197,7 @@ class ControlNodeSerial(object):  # pylint:disable=too-many-instance-attributes
         else:  # control node answer to a command
             try:
                 self.msgs.put_nowait(answer)
-            except Queue.Full:
+            except queue.Full:
                 LOGGER.error('Control node answer queue full: %r', answer)
 
     def measures_handler(self, line):
@@ -236,7 +236,7 @@ class ControlNodeSerial(object):  # pylint:disable=too-many-instance-attributes
                 self.process.stdin.write(command_str)
                 # wait for answer 1 second at max
                 answer_cn = self.msgs.get(block=True, timeout=1.0)
-            except Queue.Empty:
+            except queue.Empty:
                 LOGGER.error('control_node_serial answer timeout')
                 answer_cn = None
             except AttributeError:

--- a/gateway_code/control_nodes/cn_iotlab/cn_interface.py
+++ b/gateway_code/control_nodes/cn_iotlab/cn_interface.py
@@ -26,7 +26,12 @@ Manage sending commands and receiving messages
 """
 
 from subprocess import PIPE
-import queue
+
+try:
+    import Queue as queue
+except ImportError:
+    import queue
+
 import threading
 import logging
 from tempfile import NamedTemporaryFile

--- a/gateway_code/control_nodes/cn_iotlab/cn_interface.py
+++ b/gateway_code/control_nodes/cn_iotlab/cn_interface.py
@@ -209,7 +209,7 @@ class ControlNodeSerial(object):  # pylint:disable=too-many-instance-attributes
         """ Debug measures """
         LOGGER.debug(line)
         if self.measures_debug is not None:
-            self.measures_debug(line)
+            self.measures_debug(line)  # pylint:disable=not-callable
 
     def _reader(self):
         """ Reader thread worker.

--- a/gateway_code/control_nodes/cn_iotlab/cn_protocol.py
+++ b/gateway_code/control_nodes/cn_iotlab/cn_protocol.py
@@ -134,10 +134,9 @@ class Protocol(object):
 
         if radio is None:
             return self._stop_radio()
-
         if radio.mode == 'rssi':
             return self._config_radio_measure(radio)
-        elif radio.mode == 'sniffer':
+        if radio.mode == 'sniffer':
             return self._config_radio_sniffer(radio)
 
         raise NotImplementedError("Uknown radio mode: {}".format(radio.mode))

--- a/gateway_code/control_nodes/cn_iotlab/tests/cn_interface_test.py
+++ b/gateway_code/control_nodes/cn_iotlab/tests/cn_interface_test.py
@@ -171,7 +171,7 @@ class TestControlNodeSerial(unittest.TestCase):
         self.assertNotIn('-d', args)
 
         # OML config
-        args = self.cn._cn_interface_args('<omlc></omlc>')
+        args = self.cn._cn_interface_args(b'<omlc></omlc>')
         self.assertIn('-c', args)
         self.assertNotIn('-d', args)
         self.cn._oml_cfg_file.close()
@@ -191,7 +191,7 @@ class TestControlNodeSerial(unittest.TestCase):
 
     @mock.patch(utils.READ_CONFIG, utils.read_config_mock('m3'))
     def test_config_oml(self):
-        oml_xml_cfg = '''<omlc id='{node_id}' exp_id='{exp_id}'>\n</omlc>'''
+        oml_xml_cfg = b'''<omlc id='{node_id}' exp_id='{exp_id}'>\n</omlc>'''
         self.cn.start(oml_xml_cfg)
         self.assertIsNotNone(self.cn._oml_cfg_file)
 

--- a/gateway_code/control_nodes/cn_iotlab/tests/cn_interface_test.py
+++ b/gateway_code/control_nodes/cn_iotlab/tests/cn_interface_test.py
@@ -27,7 +27,11 @@
 # pylint: disable=maybe-no-member
 # pylint: disable=too-many-public-methods
 
-import queue
+try:
+    import Queue as queue
+except ImportError:
+    import queue
+
 import unittest
 import logging
 import mock

--- a/gateway_code/control_nodes/cn_iotlab/tests/cn_interface_test.py
+++ b/gateway_code/control_nodes/cn_iotlab/tests/cn_interface_test.py
@@ -129,8 +129,8 @@ class TestControlNodeSerial(unittest.TestCase):
         self.log_error.check(('gateway_code', 'WARNING',
                               'Control node serial not terminated, kill it'))
 
-
 # Test command sending
+
     def test_send_command(self):
         self.popen.stdin.write.side_effect = \
             (lambda *x: self.readline_ret_vals.put('start ACK\n'))

--- a/gateway_code/control_nodes/cn_iotlab/tests/cn_interface_test.py
+++ b/gateway_code/control_nodes/cn_iotlab/tests/cn_interface_test.py
@@ -27,7 +27,7 @@
 # pylint: disable=maybe-no-member
 # pylint: disable=too-many-public-methods
 
-import Queue
+import queue
 import unittest
 import logging
 import mock
@@ -48,7 +48,7 @@ class TestControlNodeSerial(unittest.TestCase):
         self.popen.terminate.side_effect = self._terminate
         self.popen.poll.return_value = None
 
-        self.readline_ret_vals = Queue.Queue(0)
+        self.readline_ret_vals = queue.Queue(0)
         self.popen.stderr.readline.side_effect = self.readline_ret_vals.get
         self.readline_ret_vals.put('cn_serial_ready\n')
 

--- a/gateway_code/control_nodes/cn_iotlab/tests/cn_iotlab_test.py
+++ b/gateway_code/control_nodes/cn_iotlab/tests/cn_iotlab_test.py
@@ -24,7 +24,6 @@
 import unittest
 from mock import Mock, patch, call
 
-from gateway_code.nodes import ControlNodeBase, import_all_nodes
 from gateway_code.control_nodes.cn_iotlab import ControlNodeIotlab
 
 
@@ -66,15 +65,6 @@ class TestCnIotlab(unittest.TestCase):
 
     def tearDown(self):
         patch.stopall()
-
-    @classmethod
-    def tearDownClass(cls):
-        # Mocking some features of the control node has side effects on
-        # following tests. We need to explicitly clear ControlNodeBase registry
-        # at the end of all unit tests and reimport the available control
-        # nodes.
-        del ControlNodeBase.__registry__[ControlNodeIotlab.TYPE]
-        import_all_nodes('control_nodes')
 
     def test_start(self):
         """Test start of iotlab control node."""

--- a/gateway_code/control_nodes/cn_iotlab/tests/cn_iotlab_test.py
+++ b/gateway_code/control_nodes/cn_iotlab/tests/cn_iotlab_test.py
@@ -45,7 +45,7 @@ class TestCnIotlab(unittest.TestCase):
         self.cn_node.cn_serial.stop.return_value = 0
 
         cn_protocol_class = patch('gateway_code.control_nodes.cn_iotlab.'
-                                  'cn_interface.ControlNodeSerial').start()
+                                  'cn_protocol.Protocol').start()
         self.cn_node.protocol = cn_protocol_class.return_value
         self.cn_node.protocol.start_stop.return_value = 0
         self.cn_node.protocol.green_led_blink.return_value = 0

--- a/gateway_code/gateway_manager.py
+++ b/gateway_code/gateway_manager.py
@@ -75,8 +75,8 @@ class GatewayManager(object):  # pylint:disable=too-many-instance-attributes
         # Setup control node
         ret = self.node_flash('control', None)  # Flash default
         if ret != 0:
-            raise StandardError("Control node flash failed: 'ret:{}'"
-                                .format(ret))
+            raise RuntimeError("Control node flash failed: 'ret:{}'"
+                               .format(ret))
         return ret
 
     @staticmethod

--- a/gateway_code/gateway_manager.py
+++ b/gateway_code/gateway_manager.py
@@ -383,7 +383,7 @@ class GatewayManager(object):  # pylint:disable=too-many-instance-attributes
         exp_dir = config.EXP_FILES_DIR.format(user=user, exp_id=exp_id)
         exp_files = {}
 
-        for name, exp_file in config.EXP_FILES.iteritems():
+        for name, exp_file in config.EXP_FILES.items():
             file_path = os.path.join(exp_dir, exp_file.format(node_id=node_id))
             exp_files[name] = config.create_user_file(file_path)
 
@@ -392,7 +392,7 @@ class GatewayManager(object):  # pylint:disable=too-many-instance-attributes
     @staticmethod
     def cleanup_user_exp_files(exp_files):
         """ Delete empty user experiment files """
-        for exp_file in exp_files.itervalues():
+        for exp_file in exp_files.values():
             config.clean_user_file(exp_file)
 
 # Exp folders creation used in tests
@@ -405,7 +405,7 @@ class GatewayManager(object):  # pylint:disable=too-many-instance-attributes
         Also useful for integration tests
         """
         exp_files_dir = config.EXP_FILES_DIR.format(user=user, exp_id=exp_id)
-        for file_dir in config.EXP_FILES.iterkeys():
+        for file_dir in config.EXP_FILES:
             try:
                 os.makedirs(exp_files_dir + file_dir)
             except OSError:

--- a/gateway_code/gateway_manager.py
+++ b/gateway_code/gateway_manager.py
@@ -27,6 +27,7 @@ import os
 import re
 import time
 import errno
+import shutil
 from threading import RLock, Timer
 
 import gateway_code.config as config
@@ -418,7 +419,6 @@ class GatewayManager(object):  # pylint:disable=too-many-instance-attributes
         Used in integration tests.
         Implemented here after the '_create' method for completeness """
         exp_files_dir = config.EXP_FILES_DIR.format(user=user, exp_id=exp_id)
-        import shutil
         try:
             shutil.rmtree(exp_files_dir)
         except OSError:

--- a/gateway_code/integration/autotest_test.py
+++ b/gateway_code/integration/autotest_test.py
@@ -23,6 +23,7 @@
 """ Integration tests running autotests """
 
 # pylint: disable=too-many-public-methods
+from __future__ import print_function
 
 import os
 import sys
@@ -42,7 +43,8 @@ class TestAutoTests(test_integration_mock.GatewayCodeMock):
         extra = query_string('channel=22&flash=1&gps=')
         ret = self.server.put('/autotest/blink', extra_environ=extra)
         ret_dict = ret.json
-        print >> sys.stderr, ret_dict
+        ret_string = '{}\n'.format(ret_dict)
+        sys.stderr.write(ret_string)
 
         self.assertEqual([], ret_dict['error'])
         self.assertIn('on_serial_echo', ret_dict['success'])

--- a/gateway_code/integration/integration_test.py
+++ b/gateway_code/integration/integration_test.py
@@ -24,6 +24,7 @@
 
 # pylint: disable=protected-access
 # pylint: disable=too-many-public-methods
+from __future__ import print_function
 
 import os
 import os.path
@@ -32,7 +33,6 @@ import math
 import subprocess
 import logging
 from threading import Thread
-from itertools import izip
 
 import pytest
 import mock
@@ -365,7 +365,7 @@ class TestComplexExperimentRunning(ExperimentRunningMock):
         # check timestamps are sorted in correct order
         for values in measures.values():
             timestamps = [t_start] + values['timestamps'] + [time.time()]
-            _sorted = all([a < b for a, b in izip(timestamps, timestamps[1:])])
+            _sorted = all([a < b for a, b in zip(timestamps, timestamps[1:])])
             self.assertTrue(_sorted)
 
         # there should be no new measures since profile update
@@ -440,8 +440,8 @@ class TestComplexExperimentRunning(ExperimentRunningMock):
         # No real reasons, just verifying that it at least the same
         for meas_type, num_meas in (('radio', 1000), ('consumption', 50000)):
             num_lines = len(open(exp_files[meas_type]).readlines())
-            print 'num measures lines: %s: %d' % (meas_type, num_lines)
-            print 'num measures ref: %s: %d' % (meas_type, num_meas)
+            print('num measures lines: %s: %d' % (meas_type, num_lines))
+            print('num measures ref: %s: %d' % (meas_type, num_meas))
             # Was failing some times, disable
             # self.assertTrue(num_meas < num_lines)
 

--- a/gateway_code/open_nodes/common/tests/node_edbg_test.py
+++ b/gateway_code/open_nodes/common/tests/node_edbg_test.py
@@ -24,7 +24,6 @@
 import unittest
 from mock import patch, Mock
 
-from gateway_code.nodes import OpenNodeBase
 from gateway_code.open_nodes.common.node_edbg import NodeEdbgBase
 from gateway_code.open_nodes.node_arduino_zero import NodeArduinoZero
 
@@ -62,11 +61,6 @@ class TestNodeEdbgBase(unittest.TestCase):
 
     def tearDown(self):
         patch.stopall()
-
-    @classmethod
-    def tearDownClass(cls):
-        # Explicitly clear OpenNodeBase registry at the end of all tests.
-        del OpenNodeBase.__registry__[NodeEdbgTest.TYPE]
 
     def test_edbg_node_basic(self):
         """Test basic functions of an edbg based node."""

--- a/gateway_code/open_nodes/common/tests/node_openocd_test.py
+++ b/gateway_code/open_nodes/common/tests/node_openocd_test.py
@@ -25,7 +25,6 @@ import unittest
 import serial
 from mock import patch, Mock
 
-from gateway_code.nodes import OpenNodeBase
 from gateway_code.open_nodes.common.node_openocd import NodeOpenOCDBase
 from gateway_code.open_nodes.node_microbit import NodeMicrobit
 
@@ -63,11 +62,6 @@ class TestNodeOpenOCDBase(unittest.TestCase):
 
     def tearDown(self):
         patch.stopall()
-
-    @classmethod
-    def tearDownClass(cls):
-        # Explicitly clear OpenNodeBase registry at the end of all tests.
-        del OpenNodeBase.__registry__[NodeOpenOCDTest.TYPE]
 
     def test_openocd_node_basic(self):
         """Test basic functions of an openocd based node."""

--- a/gateway_code/rest_server.py
+++ b/gateway_code/rest_server.py
@@ -161,7 +161,8 @@ class GatewayRest(bottle.Bottle):
             # ValueError: no files in multipart request
             return None
 
-        profile = json.load(_prof.file)  # ValueError on invalid profile
+        # ValueError on invalid profile
+        profile = json.loads(_prof.file.read().decode())
         LOGGER.debug('REST: Profile json dict: %r', profile)
         return profile
 

--- a/gateway_code/rest_server.py
+++ b/gateway_code/rest_server.py
@@ -324,12 +324,11 @@ class GatewayRest(bottle.Bottle):
         LOGGER.info('REST: Route %s registered', path)
         return self.route(path, *route_args, **route_kwargs)
 
-    def route(self, path, method='GET', callback=None, *args, **kwargs):
+    def route(self, path, method='GET', callback=None, **kwargs):
         """Add a route but catch some exceptions."""
         # pylint:disable=arguments-differ, keyword-arg-before-vararg
         callback = self._cb_wrap(callback)
-        return super(GatewayRest, self).route(path, method, callback,
-                                              *args, **kwargs)
+        return super(GatewayRest, self).route(path, method, callback, **kwargs)
 
     @staticmethod
     def _cb_wrap(func):

--- a/gateway_code/rest_server.py
+++ b/gateway_code/rest_server.py
@@ -25,6 +25,7 @@
 REST server listening to the experiment handler
 """
 
+import argparse
 import json
 import errno
 import logging
@@ -362,8 +363,6 @@ def _parse_arguments(args):
     :param args: arguments, without the script name == sys.argv[1:]
     :type args: list
     """
-    import argparse
-
     parser = argparse.ArgumentParser()
     parser.add_argument('host', type=str, help="Server address to bind to")
     parser.add_argument('port', type=int, help="Server port to bind to")

--- a/gateway_code/tests/gateway_logging_test.py
+++ b/gateway_code/tests/gateway_logging_test.py
@@ -62,7 +62,7 @@ class TestGatewayLogging(unittest.TestCase):
             log_handler.close()
 
             # file has data
-            log_content = log_file.read()
+            log_content = log_file.read().decode()
             self.assertNotEqual(0, len(log_content))
             self.assertIn(test_log, log_content)
 

--- a/gateway_code/tests/gateway_logging_test.py
+++ b/gateway_code/tests/gateway_logging_test.py
@@ -26,7 +26,11 @@
 import tempfile
 import unittest
 import logging
-from StringIO import StringIO
+
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 import mock
 

--- a/gateway_code/tests/gateway_manager_test.py
+++ b/gateway_code/tests/gateway_manager_test.py
@@ -55,7 +55,7 @@ class TestGatewayManager(unittest.TestCase):
         """ Run setup with a flash fail error """
         g_m = gateway_manager.GatewayManager()
         g_m.node_flash = mock.Mock(return_value=1)
-        with pytest.raises(StandardError):
+        with pytest.raises(RuntimeError):
             g_m.setup()
 
     def test_exp_update_profile_error(self):

--- a/gateway_code/tests/rest_server_test.py
+++ b/gateway_code/tests/rest_server_test.py
@@ -121,8 +121,8 @@ class TestRestMethods(unittest.TestCase):
         self.g_m.exp_start.return_value = 0
 
         files = []
-        files += [('firmware', 'idle.elf', 'elf32arm0X1234')]
-        files += [('profile', 'profile.json', self.PROFILE_STR)]
+        files += [('firmware', 'idle.elf', b'elf32arm0X1234')]
+        files += [('profile', 'profile.json', self.PROFILE_STR.encode())]
 
         ret = self.server.post(self.EXP_START, upload_files=files)
         self.assertEqual(0, ret.json['ret'])
@@ -135,7 +135,7 @@ class TestRestMethods(unittest.TestCase):
 
     def test_exp_start_invalid_profile(self):
 
-        files = [('profile', 'inval_profile.json', 'invalid json profile}')]
+        files = [('profile', 'inval_profile.json', b'invalid json profile}')]
         ret = self.server.post(self.EXP_START, upload_files=files)
         self.assertEqual(1, ret.json['ret'])
 
@@ -220,7 +220,7 @@ class TestRestMethods(unittest.TestCase):
 
     def test_flash_function(self):
         self.g_m.node_flash.return_value = 0
-        files = [('firmware', 'idle.elf', 'elf32arm0X1234')]
+        files = [('firmware', 'idle.elf', b'elf32arm0X1234')]
 
         # valid command
         ret = self.server.post('/open/flash', upload_files=files)

--- a/gateway_code/utils/cli/mjpg_streamer.py
+++ b/gateway_code/utils/cli/mjpg_streamer.py
@@ -25,6 +25,7 @@
 Usage: mjpg_streamer <port>
 
 """
+from __future__ import print_function
 
 import argparse
 import signal
@@ -43,10 +44,10 @@ def main():
     process = mjpg_streamer.MjpgStreamer(opts.port)
     try:
         process.start()
-        print 'Press Ctrl+C to stop'
+        print('Press Ctrl+C to stop')
         signal.pause()
     except KeyboardInterrupt:
         pass
     finally:
         process.stop()
-        print 'Stopped'
+        print('Stopped')

--- a/gateway_code/utils/cli/programmer.py
+++ b/gateway_code/utils/cli/programmer.py
@@ -61,7 +61,7 @@ def _setup_parser(cmd, board_cfg):
 def _get_node(board_cfg, control_node=False):
     if control_node:
         return board_cfg.cn_class(board_cfg.node_id, None)
-    elif board_cfg.linux_on_class is not None:
+    if board_cfg.linux_on_class is not None:
         # Linux open node
         return board_cfg.linux_on_class()
     return board_cfg.board_class()

--- a/gateway_code/utils/cli/programmer.py
+++ b/gateway_code/utils/cli/programmer.py
@@ -22,6 +22,8 @@
 
 """ Programmer to flash/reset/debug nodes  """
 
+from __future__ import print_function
+
 import os
 import signal
 import argparse
@@ -67,13 +69,13 @@ def _get_node(board_cfg, control_node=False):
 
 def _print_result(ret, cmd, node=None):
     if ret == 0:
-        print '{} OK\n'.format(cmd)
+        print('{} OK\n'.format(cmd))
     elif ret == -1:
-        print 'error: {} not supported for board {}\n'.format(cmd, node)
+        print('error: {} not supported for board {}\n'.format(cmd, node))
     elif ret == -2:
-        print 'error: {} too few arguments\n'.format(cmd)
+        print('error: {} too few arguments\n'.format(cmd))
     else:
-        print '{} KO: {}\n'.format(cmd, ret)
+        print('{} KO: {}\n'.format(cmd, ret))
 
 
 @log_to_stderr
@@ -115,7 +117,7 @@ def flash():
         try:
             firmware_path = common.abspath(firmware)
         except IOError as err:
-            print err
+            print(err)
             return 1
 
         ret = node.flash(firmware_path, opts.bin, opts.offset)
@@ -130,10 +132,10 @@ def _debug(node):
     if ret:
         return ret
     try:
-        print 'Type Ctrl+C to quit'
+        print('Type Ctrl+C to quit')
         signal.pause()
     except KeyboardInterrupt:
-        print 'Ctrl+C'
+        print('Ctrl+C')
     finally:
         node.debug_stop()
     return 0

--- a/gateway_code/utils/cli/rtl_tcp.py
+++ b/gateway_code/utils/cli/rtl_tcp.py
@@ -26,6 +26,8 @@ Usage: rtl_tcp <port> <frequency>
 
 """
 
+from __future__ import print_function
+
 import argparse
 import signal
 from .. import rtl_tcp
@@ -44,10 +46,10 @@ def main():
     process = rtl_tcp.RtlTcp(opts.port, opts.frequency)
     try:
         process.start()
-        print 'Press Ctrl+C to stop'
+        print('Press Ctrl+C to stop')
         signal.pause()
     except KeyboardInterrupt:
         pass
     finally:
         process.stop()
-        print 'Stopped'
+        print('Stopped')

--- a/gateway_code/utils/cli/serial_redirection.py
+++ b/gateway_code/utils/cli/serial_redirection.py
@@ -22,6 +22,8 @@
 
 """ CLI client for serial_redirection """
 
+from __future__ import print_function
+
 import signal
 import gateway_code.board_config as board_config
 from . import log_to_stderr
@@ -49,10 +51,10 @@ def main():
     node = _get_node(board_cfg)
     try:
         node.serial_redirection.start()
-        print 'Press Ctrl+C to stop'
+        print('Press Ctrl+C to stop')
         signal.pause()
     except KeyboardInterrupt:
         pass
     finally:
         node.serial_redirection.stop()
-        print 'Stopped'
+        print('Stopped')

--- a/gateway_code/utils/elftarget.py
+++ b/gateway_code/utils/elftarget.py
@@ -23,6 +23,7 @@
 
 from __future__ import print_function
 
+import sys
 import logging
 
 from elftools.elf.constants import SH_FLAGS
@@ -85,7 +86,6 @@ def get_elf_load_addr(firmware_path):
 
 def main():
     """Read class and machine for given firmware."""
-    import sys
     print(elf_target(sys.argv[1]))
 
 

--- a/gateway_code/utils/elftarget.py
+++ b/gateway_code/utils/elftarget.py
@@ -21,6 +21,8 @@
 
 """Validate elf target class and machine."""
 
+from __future__ import print_function
+
 import logging
 
 from elftools.elf.constants import SH_FLAGS
@@ -84,7 +86,7 @@ def get_elf_load_addr(firmware_path):
 def main():
     """Read class and machine for given firmware."""
     import sys
-    print elf_target(sys.argv[1])
+    print(elf_target(sys.argv[1]))
 
 
 if __name__ == '__main__':

--- a/gateway_code/utils/external_process.py
+++ b/gateway_code/utils/external_process.py
@@ -108,11 +108,11 @@ class ExternalProcess(threading.Thread):
         """
         sigterm = int(sigterm)
         sigint = int(sigint)
-        for _ in xrange(0, sigterm):
+        for _ in range(sigterm):
             yield signal.SIGTERM
 
         LOGGER.info('External process signal: escalading to SIGINT')
-        for _ in xrange(0, sigint):
+        for _ in range(sigint):
             yield signal.SIGINT
 
         LOGGER.warning('External process signal: escalading to SIGKILL')

--- a/gateway_code/utils/external_process.py
+++ b/gateway_code/utils/external_process.py
@@ -34,6 +34,7 @@ LOGGER = logging.getLogger('gateway_code')
 
 
 class ExternalProcess(threading.Thread):
+    # pylint: disable=no-member,method-hidden
     """ Class running an external process in background
 
     It's implemented as a stoppable thread running the process in a loop.
@@ -78,8 +79,9 @@ class ExternalProcess(threading.Thread):
         # kill
         while self.is_alive():
             try:
-                sig = signals.next()
-                self.process.send_signal(sig)
+                if self.process is not None:
+                    sig = next(signals)
+                    self.process.send_signal(sig)
             except OSError as err:
                 # errno == 3 'No such proccess', already terminated: OK
                 assert err.errno == 3, 'Unknown error num: %r' % err.errno
@@ -146,4 +148,5 @@ class ExternalProcess(threading.Thread):
 
         ret = self.check_error(retcode)
         time.sleep(0.5)  # prevent quick loop
+        self._started.clear()
         return ret

--- a/gateway_code/utils/ftdi_check.py
+++ b/gateway_code/utils/ftdi_check.py
@@ -45,7 +45,8 @@ def ftdi_check(node, ftdi_type, description=None):
     found = (dev_number > 0) and \
             ((description is None) or
              ftdi_lookup_description(lines[3:], description))
-    LOGGER.info(("" if found else "No ") + "%r node ftdi found" % node)
+    msg = "{}{} node ftdi found".format(("" if found else "No "), node)
+    LOGGER.info(msg)
     return 0 if found else 1
 
 

--- a/gateway_code/utils/node_connection.py
+++ b/gateway_code/utils/node_connection.py
@@ -40,13 +40,14 @@ class OpenNodeConnection(object):
         self.address = (host, port)
         self.timeout = timeout
         self.fd = None  # pylint:disable=invalid-name
+        self.sock = None
 
     def start(self):
         """ Connect to the serial_redirection """
         try:
-            sock = self.try_connect(self.address)
-            sock.settimeout(self.timeout)  # pylint:disable=no-member
-            self.fd = sock.makefile('rw')
+            self.sock = self.try_connect(self.address)
+            self.sock.settimeout(self.timeout)  # pylint:disable=no-member
+            self.fd = self.sock.makefile('rw')
             return 0
         except IOError:
             return 1
@@ -56,6 +57,7 @@ class OpenNodeConnection(object):
         for reconnection """
         self.fd.close()
         self.fd = None
+        self.sock = None
 
         # Wait redirection restarted
         # Should not wait on start because connection should work instantly

--- a/gateway_code/utils/subprocess_timeout.py
+++ b/gateway_code/utils/subprocess_timeout.py
@@ -26,10 +26,9 @@ It should help mocking tests as it is not necessary to know if using
 subprocess32 on subrocess.
 """
 
-import sys
-if sys.version_info[0] < 3:
+try:
     from subprocess32 import call, Popen, TimeoutExpired
-else:  # pragma: no cover
+except ImportError:
     from subprocess import call, Popen
     from subprocess import TimeoutExpired  # pylint:disable=no-name-in-module
 

--- a/gateway_code/utils/tests/elftarget_test.py
+++ b/gateway_code/utils/tests/elftarget_test.py
@@ -32,6 +32,7 @@ except ImportError:
     from io import StringIO
 
 import mock
+import pytest
 from testfixtures import LogCapture
 
 from gateway_code.open_nodes.node_m3 import NodeM3
@@ -55,16 +56,16 @@ class TestElfTarget(unittest.TestCase):
         target = elftarget.elf_target(firmware('leonardo_idle.elf'))
         self.assertEqual(target, ('ELFCLASS32', 'EM_AVR'))
 
-    def test_invalid_elf(self):
+    def test_invalid_elf(self):  # pylint: disable=no-self-use
         """Test invalid elf files or non elf files."""
         # elf relocation file
-        self.assertRaisesRegexp(
-            ValueError, 'Not an executable elf file: ET_REL',
-            elftarget.elf_target, firmware('idle.c.o'))
+        with pytest.raises(ValueError) as exc_info:
+            elftarget.elf_target(firmware('idle.c.o'))
+        assert 'Not an executable elf file: ET_REL' in str(exc_info.value)
         # wsn430 firmware
-        self.assertRaisesRegexp(
-            ValueError, 'Not a valid elf file',
-            elftarget.elf_target, firmware('wsn430_print_uids.hex'))
+        with pytest.raises(ValueError) as exc_info:
+            elftarget.elf_target(firmware('wsn430_print_uids.hex'))
+        assert 'Not a valid elf file' in str(exc_info.value)
 
 
 class TestElfTargetIsCompatibleWithNode(unittest.TestCase):

--- a/gateway_code/utils/tests/elftarget_test.py
+++ b/gateway_code/utils/tests/elftarget_test.py
@@ -25,7 +25,11 @@ import os
 import logging
 import unittest
 import runpy
-from cStringIO import StringIO
+
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 import mock
 from testfixtures import LogCapture

--- a/gateway_code/utils/tests/node_connection_test.py
+++ b/gateway_code/utils/tests/node_connection_test.py
@@ -22,6 +22,8 @@
 
 """ Test node_connection.OpenNodeConnection """
 
+from __future__ import print_function
+
 import time
 import unittest
 import threading
@@ -71,9 +73,9 @@ class TestOpenNodeConnection(unittest.TestCase):
                 time.sleep(self.write_delay)
                 self.redirect.stdin.write('READ_LINE %s' % line)
         except (AttributeError, IOError) as err:
-            print err
+            print(err)
         else:
-            print "_open_node_thread stopped"
+            print("_open_node_thread stopped")
 
     def test_sending_multiple_commands(self):
         with OpenNodeConnection() as conn:

--- a/gateway_code/utils/tests/node_connection_test.py
+++ b/gateway_code/utils/tests/node_connection_test.py
@@ -67,11 +67,12 @@ class TestOpenNodeConnection(unittest.TestCase):
     def _open_node_thread(self):
         try:
             while True:
-                line = self.redirect.stdout.readline()
+                line = self.redirect.stdout.readline().decode()
                 if not line:
                     break
                 time.sleep(self.write_delay)
-                self.redirect.stdin.write('READ_LINE %s' % line)
+                self.redirect.stdin.write('READ_LINE {}'.format(line).encode())
+                self.redirect.stdin.flush()
         except (AttributeError, IOError) as err:
             print(err)
         else:

--- a/gateway_code/utils/tests/serial_redirection_test.py
+++ b/gateway_code/utils/tests/serial_redirection_test.py
@@ -82,15 +82,16 @@ class TestSerialRedirection(_SerialRedirectionTestCase):
             conn = OpenNodeConnection.try_connect(('0.0.0.0', 20000))
 
             # TCP send
-            sock_txt = 'HelloFromSock: %u\n' % i
+            sock_txt = b'HelloFromSock: %u\n' % i
             conn.send(sock_txt)
             ret = self.serial.stdout.read(len(sock_txt))
             self.assertEqual(ret, sock_txt)
             logging.debug(ret)
 
             # Serial send
-            serial_txt = 'HelloFromSerial %u\n' % i
+            serial_txt = b'HelloFromSerial %u\n' % i
             self.serial.stdin.write(serial_txt)
+            self.serial.stdin.flush()
             ret = conn.recv(len(serial_txt))
             self.assertEqual(ret, serial_txt)
             logging.debug(ret)

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ testpaths = gateway_code
 
 [flake8]
 # E722 do not use bare except   
-ignore = E722
+ignore = E722,W504
 exclude = *.egg,.tox,doc
 
 [pep8]
@@ -16,7 +16,15 @@ exclude = *.egg,.tox,doc
 [lint]
 lint-persistent = no
 lint-reports = no
-lint-disable = locally-disabled,star-args,duplicate-code
+lint-disable =
+    locally-disabled,
+    star-args,
+    duplicate-code,
+    super-init-not-called,
+    no-init,
+    old-style-class,
+    useless-object-inheritance,
+    unnecessary-pass
 lint-msg-template = "{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}"
 lint-exclude-packages = .tox,*.egg
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ Pylint and pep8 checker:
     python setup.py pep8
 """
 
-from setuptools import setup, Command, Extension, find_packages
+from setuptools import setup, Command, find_packages
 from setuptools.command.build_ext import build_ext
 from distutils.command.install import install
 
@@ -71,7 +71,6 @@ def get_version(package):
 
 
 SCRIPTS = glob('bin/scripts/*')
-SCRIPTS += ['control_node_serial/control_node_serial_interface']
 
 INSTALL_REQUIRES = ['argparse', 'bottle', 'paste', 'pyserial']
 INSTALL_REQUIRES += ['pyelftools']
@@ -177,11 +176,16 @@ class Release(install):
         execute(self, post_install, [self])
 
 
-PACKAGE_DATA = {'static': ['static/*']}
+PACKAGE_DATA = {
+    'static': ['static/*'],
+    'control_node_serial_interface':
+        ['control_node_serial/control_node_serial_interface']
+}
 
 setup(name=PACKAGE,
       version=get_version(PACKAGE),
       description='Linux Gateway code',
+      long_description="Linux Gateway code",
       author='IoT-Lab Team',
       author_email='admin@iot-lab.info',
       url='http://www.iot-lab.info',
@@ -191,7 +195,6 @@ setup(name=PACKAGE,
       scripts=SCRIPTS,
       include_package_data=True,
       package_data=PACKAGE_DATA,
-      ext_modules=[Extension('control_node_serial_interface', [])],
 
       cmdclass={
           'build_ext': BuildExt,

--- a/tests_utils/generate_dot_archi.py
+++ b/tests_utils/generate_dot_archi.py
@@ -111,7 +111,7 @@ def generate_dot(files):
             ret += ' [style=invis, constraint=false]'
         ret += '\n'
 
-    for cluster, nodes in extract_clusters(files).iteritems():
+    for cluster, nodes in extract_clusters(files).items():
         ret += str_cluster(cluster, nodes)
 
     # clusters
@@ -126,7 +126,7 @@ def main():
     dot_path = '%s.dot' % FILE
     png_path = '%s.png' % FILE
 
-    files = check_output('find gateway_code/ -name \*py'
+    files = check_output('find gateway_code/ -name \\*py'
                          ' ! -name __init__.py'
                          ' -not -path "*integration/*"'
                          ' -not -path "*cli/*"'

--- a/tests_utils/test-requirements.txt
+++ b/tests_utils/test-requirements.txt
@@ -3,7 +3,7 @@ pytest-pep8
 pytest-cov
 setuptools-lint
 pylint
-flake8==3.5.0
+flake8
 nosexcover
 mock
 WebTest

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = copying,control_node_serial,{py27,py35,py36,py37,py38}-{tests,code_check}
+envlist = copying,control_node_serial,{py27,py35,py36,py37,py38}-{tests,lint}
 skip_missing_interpreters = true
 
 [testenv]
@@ -7,12 +7,13 @@ passenv = IOTLAB_GATEWAY_CFG_DIR
 deps=
     -rtests_utils/test-requirements.txt
 commands=
-    tests:      {[testenv:tests]commands}
-    code_check: {[testenv:code_check]commands}
+    tests: {[testenv:tests]commands}
+    lint:  {[testenv:lint]commands}
 
 [testenv:tests]
 whitelist_externals =
     /bin/bash
+    /usr/bin/bash
     /usr/bin/make
 deps = -rtests_utils/test-requirements.txt
 commands =
@@ -28,22 +29,24 @@ commands = codecov
 
 
 [testenv:copying]
-whitelist_externals = /bin/bash
+whitelist_externals =
+    /bin/bash
+    /usr/bin/bash
 commands=
     bash tests_utils/check_license.sh
 
 
-[testenv:code_check]
-whitelist_externals = /bin/bash
+[testenv:lint]
 deps = -rtests_utils/test-requirements.txt
 commands =
-    bash -c "set -o pipefail;python setup.py lint | tee pylint.out"
-    bash -c "set -o pipefail;flake8 | tee flake8.out"
+    python setup.py lint
+    flake8
 
 
 [testenv:integration]
 whitelist_externals =
     /bin/bash
+    /usr/bin/bash
     /bin/echo
     /usr/bin/make
     /usr/bin/codecov

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,16 @@
 [tox]
-envlist = copying, test, code_check, control_node_serial
-
-# infos:
-#   can't hide return value before tox 1.9
-#   and can't do bash stuff directly, so call bash
+envlist = copying,control_node_serial,{py27,py35,py36,py37,py38}-{tests,code_check}
+skip_missing_interpreters = true
 
 [testenv]
-basepython = python2
 passenv = IOTLAB_GATEWAY_CFG_DIR
+deps=
+    -rtests_utils/test-requirements.txt
+commands=
+    tests:      {[testenv:tests]commands}
+    code_check: {[testenv:code_check]commands}
 
-
-[testenv:test]
+[testenv:tests]
 whitelist_externals =
     /bin/bash
     /usr/bin/make


### PR DESCRIPTION
- Unit tests are now working on Python 2.7, 3.6 and 3.8 (all tested)
- Lots of lints fixed

In the current state, the integration tests are failing (Python 2) because of commit 5a2df5b. To be able to test with Python 3, it would be better to update the Python packages installed in the Yocto image and deploy this image on one of the ci gateways.