### PR TITLE
Refactor Docker images handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,21 +4,6 @@ sudo: required
 services:
   - docker
 
-cache:
-  directories:
-    - docker
-
-before_install:
-    # If there is a cache, load it in docker
-  - if [ -e docker/previous_image.tar.gz ]; then docker load -i docker/previous_image.tar.gz; fi
-
-install:
-  - docker build -t iot-lab-gateway --cache-from=iot-lab-gateway .
-  - docker build -t iot-lab-gateway-tests tests
-
-before_cache:
-  - docker save -o docker/previous_image.tar.gz iot-lab-gateway
-
 after_success:
   - ci_env=`bash <(curl -s https://codecov.io/env)`
   - docker run -v $PWD:/shared -e LOCAL_USER_ID=`id -u ${USER}` $ci_env iot-lab-gateway-tests tox -e upload_coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ RUN apt-get update && \
     apt-get install -y git \
         python-dev \
         python-setuptools \
+        python3-dev \
+        python3-setuptools \
         socat && \
     apt-get clean
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ SERIAL_PORT ?= 20000
 CONTROL_NODE_TYPE ?= no
 POSARGS ?=
 
+DOCKER_IMAGE ?= fitiotlab/iot-lab-gateway
+DOCKER_IMAGE_TEST ?= $(DOCKER_IMAGE)-tests
+
 .PHONY: build-docker-image build-docker-image-test setup-udev-rules \
 	    test local-test \
 	    integration-test local-integration-test \
@@ -12,10 +15,10 @@ POSARGS ?=
 	    setup-cfg-dir
 
 build-docker-image:
-	docker build -t iot-lab-gateway .
+	docker build -t $(DOCKER_IMAGE) .
 
 build-docker-image-test: build-docker-image
-	docker build -t iot-lab-gateway-tests tests
+	docker build -t $(DOCKER_IMAGE_TEST) tests
 
 setup-udev-rules:
 	sudo cp bin/rules.d/* /etc/udev/rules.d/.
@@ -31,7 +34,7 @@ test:
 	docker run -ti --rm \
 		-v $(PWD):/shared \
 		-e LOCAL_USER_ID=`id -u $(USER)` \
-		iot-lab-gateway-tests tox $(POSARGS)
+		$(DOCKER_IMAGE_TEST) tox $(POSARGS)
 
 integration-test: setup-cfg-dir
 	docker run -ti --rm \
@@ -41,7 +44,7 @@ integration-test: setup-cfg-dir
 		-e LOCAL_USER_ID=`id -u $(USER)` \
 		-e IOTLAB_GATEWAY_CFG_DIR=/shared/cfg_dir \
 		--privileged \
-		iot-lab-gateway-tests tox -e test $(POSARGS)
+		$(DOCKER_IMAGE_TEST) tox -e test $(POSARGS)
 
 GW_USER = test
 EXPERIMENT = 123
@@ -67,7 +70,7 @@ run: setup-cfg-dir setup-exp-dir
 		-p $(PORT):8080 \
 		-p $(SERIAL_PORT):20000 \
 		--privileged \
-		iot-lab-gateway
+		$(DOCKER_IMAGE)
 
 local-test:
 	tox


### PR DESCRIPTION
- Use images built on DockerHub
- Drop the image build in Travis
- Install Python 3 in base image
- Refactor a bit the Makefile