### PR TITLE
Dockerfile: update base image + reorganize apt calls + bump openocd dev version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ RUN apt-get update && \
         binutils \
         # AVR (arduino like)
         avrdude \
+        avarice \
         && \
     apt-get clean
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:19.10
 MAINTAINER Cédric Roussel <cedric.roussel@inria.fr>
 
 # This file is a part of IoT-LAB gateway_code

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ RUN git clone https://github.com/ntfreak/openocd openocd10 && \
     cd openocd10 && \
     git checkout v0.10.0 && \
     ./bootstrap && \
-    ./configure --enable-cmsis-dap --enable-hidapi-libusb && \
+    ./configure --enable-cmsis-dap --enable-hidapi-libusb --disable-werror && \
     make && \
     make install && \
     cd .. && rm -rf openocd10

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,19 +20,20 @@ MAINTAINER Cédric Roussel <cedric.roussel@inria.fr>
 # The fact that you are presently reading this means that you have had
 # knowledge of the CeCILL license and that you accept its terms.
 
-#MANDATORY
+ENV DEBIAN_FRONTEND noninteractive
+
+ENV LC_ALL C.UTF-8
+ENV LANG C.UTF-8
+
 RUN apt-get update && \
     apt-get install -y git \
+        # MANDATORY
         python-dev \
         python-setuptools \
         python3-dev \
         python3-setuptools \
-        socat && \
-    apt-get clean
-
-#openocd
-RUN apt-get update && \
-    apt-get install -y \
+        socat \
+        # openocd
         build-essential \
         libftdi-dev \
         libhidapi-dev \
@@ -44,29 +45,29 @@ RUN apt-get update && \
         libxml2-dev \
         ruby \
         libtool \
-        pkg-config && \
-    apt-get clean
-
-#AVR (arduino like)
-RUN apt-get update && \
-    apt-get install -y \
-        avrdude && \
-    apt-get clean
-
-#To do http requests (to upload an experiment for instance)
-RUN apt-get update && \
-    apt-get install -y \
-        curl && \
+        pkg-config \
+        # To do http requests (to upload an experiment for instance)
+        curl \
+        # liboml2 install
+        autoconf \
+        automake \
+        libtool \
+        gnulib \
+        libpopt-dev \
+        libxml2 \
+        libsqlite3-dev \
+        pkg-config \
+        libxml2-utils \
+        # cc2538 for firefly
+        python-pip \
+        binutils \
+        # AVR (arduino like)
+        avrdude \
+        && \
     apt-get clean
 
 #liboml2 install
 RUN mkdir /var/www && chown www-data:www-data /var/www
-
-RUN apt-get update && \
-    apt-get install -y \
-        autoconf automake libtool gnulib libpopt-dev \
-        libxml2 libsqlite3-dev pkg-config libxml2-utils && \
-    apt-get clean
 
 RUN git clone https://github.com/mytestbed/oml.git && \
     cd oml && \
@@ -118,8 +119,6 @@ RUN git clone https://github.com/iot-lab/iot-lab-ftdi-utils/  && \
 # cc2538 for firefly
 RUN git clone https://github.com/JelmerT/cc2538-bsl && \
     cp cc2538-bsl/cc2538-bsl.py /usr/bin/. && \
-    apt-get update && \
-    apt-get install -y python-pip binutils && \
     pip install intelhex
 
 WORKDIR /setup_dir

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ RUN git clone https://github.com/ntfreak/openocd openocd10 && \
 #openocd dev
 RUN git clone https://github.com/ntfreak/openocd openocd-dev && \
     cd openocd-dev && \
-    git checkout 05e0d633bad9e8b0bdfaf16fc76ab1f9d9419d8b && \
+    git checkout 7c88e76a76588fa0e3ab645adfc46e8baff6a3e4 && \
     ./bootstrap && \
     ./configure --prefix=/opt/openocd-dev --enable-cmsis-dap --enable-hidapi-libusb && \
     make && \


### PR DESCRIPTION
- Use Ubuntu 19.10 as base image. Using the very last Ubuntu 20.04 would require too much work: Python 3 is the default. So 19.10 is the last Ubuntu that comes with Python 2 as default version
- Move installation of all apt packages in a single layer
- Disable warning as errors when building openocd 0.10 otherwise it doesn't build with the gcc version provided in Ubuntu 19.10
- Bump the openocd dev version to a very recent commit in master (from 07/2020)

Note that this PR breaks the integration tests (`test_simple_experiment`) on boards based on OpenOCD because the `gdb` version is Ubuntu 19.10 is not able to fully control an ARM target. But it is required for new open nodes that will come.