### PR TITLE
fix Python3 support with encoding

### DIFF
--- a/gateway_code/autotest/autotest.py
+++ b/gateway_code/autotest/autotest.py
@@ -115,8 +115,8 @@ class AutoTestManager(object):
     @staticmethod
     def get_local_mac_addr():
         """ Get eth0 mac address """
-        mac_addr = check_output(MAC_CMD, stderr=STDOUT, shell=True).strip()
-        return mac_addr
+        mac_addr = check_output(MAC_CMD, stderr=STDOUT, shell=True)
+        return mac_addr.decode().strip()
 
     def setup_control_node(self):
         """ setup connection with control_node"""
@@ -210,8 +210,6 @@ class AutoTestManager(object):
             ret_val += self._setup_linux_open_node()
         else:
             ret_val += self._setup_open_node()
-
-        self.on_serial.empty()  # flush messages that can be bufferred
 
         if ret_val != 0:  # pragma: no cover
             raise FatalError('Setup Open Node failed')
@@ -600,7 +598,7 @@ class AutoTestManager(object):
         # ['ACK', sensor, '3.6E-2', '-1.56E-1', '1.0320001', unit]
 
         values = self._run_test(
-            10, [sensor], (lambda x: tuple([float(val) for val in x[2:5]])))
+            10, [sensor], (lambda x: tuple(float(val) for val in x[2:5])))
 
         test_ok = len(set(values)) > 1  # got different values
         return self._check(tst_ok(test_ok), sensor, values)
@@ -777,7 +775,7 @@ class AutoTestManager(object):
 
         # check that consumption is higher with each led than with no leds on
         led_0 = led_consumption.pop(0)
-        test_ok = all([led_0 < v for v in led_consumption])
+        test_ok = all(led_0 < v for v in led_consumption)
         ret_val += self._check(tst_ok(test_ok), 'leds_using_conso',
                                (led_0, led_consumption))
         return ret_val
@@ -818,13 +816,13 @@ def extract_measures(meas_list):
         if meas[1] == 'consumption_measure':
             # ['measures_debug', 'consumption_measure'
             #     '1378387028.906210', '0.257343', '3.216250', '0.080003']
-            values = tuple([float(v) for v in meas[3:6]])
+            values = tuple(float(v) for v in meas[3:6])
             meas_dict['consumption']['values'].append(values)
             meas_dict['consumption']['timestamps'].append(float(meas[2]))
         elif meas[1] == 'radio_measure':
             # ['measures_debug:', 'radio_measure',
             #      '1378466517.186216', '11', '-91']
-            values = tuple([int(v) for v in meas[3:5]])
+            values = tuple(int(v) for v in meas[3:5])
             meas_dict['radio']['values'].append(values)
             meas_dict['radio']['timestamps'].append(float(meas[2]))
         else:

--- a/gateway_code/autotest/open_linux_interface.py
+++ b/gateway_code/autotest/open_linux_interface.py
@@ -87,8 +87,7 @@ class OpenLinuxConnection(object):
     def get_mac_addr(self):
         """ Get eth0 mac address """
         mac_addr_s = self.ssh_run(MAC_CMD)
-        mac_addr = mac_addr_s.strip()
-        return mac_addr
+        return mac_addr_s.strip()
 
     def flash(self):
         """ Flash firmware on open node """
@@ -105,7 +104,7 @@ class OpenLinuxConnection(object):
         LOGGER.debug(cmd)
 
         output = check_output(shlex.split(cmd), stderr=STDOUT)
-        return output
+        return output.decode()
 
     def scp(self, src, dest):
         """ SCP scr to Linux node at dest """

--- a/gateway_code/control_nodes/cn_iotlab/cn_interface.py
+++ b/gateway_code/control_nodes/cn_iotlab/cn_interface.py
@@ -123,7 +123,7 @@ class ControlNodeSerial(object):  # pylint:disable=too-many-instance-attributes
             return None
 
         # Save xml configuration in a temporary file
-        cfg_file = NamedTemporaryFile(suffix='--oml.config')
+        cfg_file = NamedTemporaryFile(suffix='--oml.config', mode='w')
         cfg_file.write(oml_xml_config)
         cfg_file.flush()
 
@@ -217,7 +217,7 @@ class ControlNodeSerial(object):  # pylint:disable=too-many-instance-attributes
         Reads and handle control node answers
         """
         while self.process.poll() is None:
-            line = self.process.stderr.readline()
+            line = self.process.stderr.readline().decode()
             if line == '':
                 break
             self._handle_answer(line.strip())
@@ -238,7 +238,8 @@ class ControlNodeSerial(object):  # pylint:disable=too-many-instance-attributes
             common.empty_queue(self.msgs)
             try:
                 LOGGER.debug('control_node_cmd: %r', command_args)
-                self.process.stdin.write(command_str)
+                self.process.stdin.write(command_str.encode())
+                self.process.stdin.flush()
                 # wait for answer 1 second at max
                 answer_cn = self.msgs.get(block=True, timeout=1.0)
             except queue.Empty:

--- a/gateway_code/control_nodes/cn_iotlab/tests/cn_interface_test.py
+++ b/gateway_code/control_nodes/cn_iotlab/tests/cn_interface_test.py
@@ -54,7 +54,7 @@ class TestControlNodeSerial(unittest.TestCase):
 
         self.readline_ret_vals = queue.Queue(0)
         self.popen.stderr.readline.side_effect = self.readline_ret_vals.get
-        self.readline_ret_vals.put('cn_serial_ready\n')
+        self.readline_ret_vals.put(b'cn_serial_ready\n')
 
         self.cn = cn_interface.ControlNodeSerial('tty')
         self.log_error = LogCapture('gateway_code', level=logging.WARNING)
@@ -65,7 +65,7 @@ class TestControlNodeSerial(unittest.TestCase):
         self.log_error.uninstall()
 
     def _terminate(self):
-        self.readline_ret_vals.put('')
+        self.readline_ret_vals.put(b'')
 
     def test_normal_start_stop(self):
         ret_start = self.cn.start()
@@ -94,7 +94,7 @@ class TestControlNodeSerial(unittest.TestCase):
     def test_stop_with_cn_interface_allready_stopped(self):
 
         # Simulate cn_interface stopped
-        self.readline_ret_vals.put('')
+        self.readline_ret_vals.put(b'')
         self.popen.stdin.write.side_effect = IOError()
         self.popen.terminate.side_effect = OSError()
 
@@ -133,7 +133,7 @@ class TestControlNodeSerial(unittest.TestCase):
 
     def test_send_command(self):
         self.popen.stdin.write.side_effect = \
-            (lambda *x: self.readline_ret_vals.put('start ACK\n'))
+            (lambda *x: self.readline_ret_vals.put(b'start ACK\n'))
 
         self.cn.start()
         ret = self.cn.send_command(['start', 'DC'])
@@ -152,15 +152,15 @@ class TestControlNodeSerial(unittest.TestCase):
 
     def test_answer_and_answer_with_queue_full(self):
         # get two answers without sending command
-        self.readline_ret_vals.put('set ACK\n')
-        self.readline_ret_vals.put('start ACK\n')
+        self.readline_ret_vals.put(b'set ACK\n')
+        self.readline_ret_vals.put(b'start ACK\n')
 
         self.cn.start()
         self.cn.stop()
 
         self.log_error.check(
             ('gateway_code', 'ERROR',
-             'Control node answer queue full: {}'.format(['start', 'ACK'])))
+             'Control node answer queue full: {}'.format([u'start', u'ACK'])))
 
 # _cn_interface_args
 
@@ -171,7 +171,7 @@ class TestControlNodeSerial(unittest.TestCase):
         self.assertNotIn('-d', args)
 
         # OML config
-        args = self.cn._cn_interface_args(b'<omlc></omlc>')
+        args = self.cn._cn_interface_args('<omlc></omlc>')
         self.assertIn('-c', args)
         self.assertNotIn('-d', args)
         self.cn._oml_cfg_file.close()
@@ -191,7 +191,7 @@ class TestControlNodeSerial(unittest.TestCase):
 
     @mock.patch(utils.READ_CONFIG, utils.read_config_mock('m3'))
     def test_config_oml(self):
-        oml_xml_cfg = b'''<omlc id='{node_id}' exp_id='{exp_id}'>\n</omlc>'''
+        oml_xml_cfg = '''<omlc id='{node_id}' exp_id='{exp_id}'>\n</omlc>'''
         self.cn.start(oml_xml_cfg)
         self.assertIsNotNone(self.cn._oml_cfg_file)
 

--- a/gateway_code/integration/integration_test.py
+++ b/gateway_code/integration/integration_test.py
@@ -57,10 +57,10 @@ APP_JSON = 'application/json'
 GATEWAY_LOGGER = logging.getLogger('gateway_code')
 
 
-def file_tuple(fieldname, file_path):
+def file_tuple(fieldname, file_path, mode='rb'):
     """ Return upload_file tuple """
     filename = os.path.basename(file_path)
-    with open(file_path) as file_fd:
+    with open(file_path, mode=mode) as file_fd:
         content = file_fd.read()
 
     return (fieldname, filename, content)
@@ -305,7 +305,8 @@ class TestComplexExperimentRunning(ExperimentRunningMock):
     def _update_profile(self, profilefilename=None, assert_ret=True):
         """Update profile with given 'profilename' file."""
         if profilefilename is not None:
-            profile = file_tuple('profile', CURRENT_DIR + profilefilename)[-1]
+            profile = file_tuple('profile', CURRENT_DIR + profilefilename,
+                                 mode='r')[-1]
         else:
             profile = ''
 
@@ -365,7 +366,7 @@ class TestComplexExperimentRunning(ExperimentRunningMock):
         # check timestamps are sorted in correct order
         for values in measures.values():
             timestamps = [t_start] + values['timestamps'] + [time.time()]
-            _sorted = all([a < b for a, b in zip(timestamps, timestamps[1:])])
+            _sorted = all(a < b for a, b in zip(timestamps, timestamps[1:]))
             self.assertTrue(_sorted)
 
         # there should be no new measures since profile update

--- a/gateway_code/utils/ftdi_check.py
+++ b/gateway_code/utils/ftdi_check.py
@@ -40,7 +40,7 @@ def ftdi_check(node, ftdi_type, description=None):
     LOGGER.info("Check %r node ftdi", node)
 
     output = subprocess.check_output(['ftdi-devices-list', '-t', ftdi_type])
-    lines = (output.splitlines())
+    lines = (output.decode('latin-1').splitlines())
     dev_number = ftdi_parse_device_number(lines[2])
     found = (dev_number > 0) and \
             ((description is None) or

--- a/gateway_code/utils/node_connection.py
+++ b/gateway_code/utils/node_connection.py
@@ -94,11 +94,6 @@ class OpenNodeConnection(object):
         LOGGER.debug("Command answer: %r", answer)
         return answer
 
-    def empty(self):
-        """ Empty out buffer """
-        while self._readline() is not None:
-            pass  # pragma: no cover
-
     def _writeline(self, line):
         """ Write a line """
         self.fd.write(line + '\n')

--- a/gateway_code/utils/serial_expect.py
+++ b/gateway_code/utils/serial_expect.py
@@ -49,7 +49,7 @@ class SerialExpect(object):
 
     def send(self, data):
         """ Write given data to serial with newline"""
-        self.fd.write(data + '\n')
+        self.fd.write((data + '\n').encode())
 
     def expect_list(self, pattern_list, timeout=float('+inf')):
         """ expect multiple patterns """
@@ -88,11 +88,11 @@ class SerialExpect(object):
 
             # add new bytes to remaining of last line
             # no multiline patterns
-            buff = buff.split('\n')[-1] + read_bytes
+            buff = buff.split('\n')[-1] + read_bytes.decode('latin-1')
 
             # print each line with timestamp on front
             if self.logger is not None:
-                print_buff += read_bytes
+                print_buff += read_bytes.decode('latin-1')
                 lines = print_buff.splitlines()
 
                 # keep last line in buffer if not newline terminated

--- a/gateway_code/utils/tests/ftdi_check_test.py
+++ b/gateway_code/utils/tests/ftdi_check_test.py
@@ -45,7 +45,7 @@ class TestFtdiCheck(unittest.TestCase):
                 Description: ControlNode
                 Serial:
             All done, success!
-            ''')
+            ''').encode('latin-1')
         self.assertEqual(0, ftdi_check('control', '4232'))
         m_check_output.assert_called_with(['ftdi-devices-list', '-t', '4232'])
 
@@ -56,7 +56,7 @@ class TestFtdiCheck(unittest.TestCase):
             Listing FT2232 devices...
             No FTDI device found
             All done, success!
-            ''')
+            ''').encode('latin-1')
         self.assertEqual(1, ftdi_check('open', '2232'))
         m_check_output.assert_called_with(['ftdi-devices-list', '-t', '2232'])
 
@@ -76,7 +76,7 @@ class TestFtdiCheck(unittest.TestCase):
                 Description: M3
                 Serial:
             All done, success!
-            ''')
+            ''').encode('latin-1')
         self.assertEqual(0, ftdi_check('control', '4232'))
         self.assertEqual(0, ftdi_check('control', '4232', description='M3'))
         m_check_output.assert_called_with(['ftdi-devices-list', '-t', '4232'])

--- a/gateway_code/utils/tests/serial_expect_test.py
+++ b/gateway_code/utils/tests/serial_expect_test.py
@@ -59,7 +59,7 @@ class TestSerialExpect(unittest.TestCase):
             return self.read_ret.pop(0)
         except IndexError:
             time.sleep(0.1)
-            return ''
+            return b''
 
     def test_run_init_and_del(self):
         self.serial_class.assert_called_with('TTY', 1234, timeout=0.1)
@@ -67,40 +67,41 @@ class TestSerialExpect(unittest.TestCase):
 
     def test_send(self):
         self.expect.send('a_command')
-        self.serial.write.assert_called_with('a_command\n')
+        self.serial.write.assert_called_with(b'a_command\n')
 
     def test_expect(self):
-        self.read_ret = ['abcde12345']
+        self.read_ret = [b'abcde12345']
         ret = self.expect.expect('ab.*45')
         self.assertEqual('abcde12345', ret)
 
     def test_expect_empty(self):
         self.read_ret = []
-        assert self.serial.read(1) == ''
+        assert self.serial.read(1) == b''
 
     def test_expect_timeout(self):
-        self.read_ret = ['wrong_text']
+        self.read_ret = [b'wrong_text']
         ret = self.expect.expect('ab.*45', 0.0)
         self.assertEqual('', ret)  # timeout
 
     def test_expect_on_multiple_reads(self):
-        self.read_ret = ['a234567890123456', '', 'b234567890123456', '123456c']
-        expected_ret = ''.join(self.read_ret)
+        self.read_ret = [b'a234567890123456', b'', b'b234567890123456',
+                         b'123456c']
+        expected_ret = (b''.join(self.read_ret)).decode()
 
         ret = self.expect.expect('a.*c')
         self.assertEqual(expected_ret, ret)
 
     def test_expect_list(self):
-        self.read_ret = ['aaaa']
+        self.read_ret = [b'aaaa']
         ret = self.expect.expect_list(['a', 'b'])
         self.assertEqual('a', ret)
 
-        self.read_ret = ['b']
+        self.read_ret = [b'b']
         ret = self.expect.expect_list(['a', 'b'])
         self.assertEqual('b', ret)
 
     def test_expect_read_new_line(self):
-        self.read_ret = ['ab\ncd', 'a00d']
+        self.read_ret = [b'ab\ncd', b'a00d']
         ret = self.expect.expect('a.*d')
         self.assertEqual('a00d', ret)
 
@@ -133,7 +134,7 @@ class TestSerialExpect(unittest.TestCase):
         logger.debug = mock.Mock(side_effet=ValueError(""))
         self.expect = serial_expect.SerialExpect('TTY', 1234, logger=logger)
 
-        self.read_ret = ['123\n456', '789\n', 'abcd']
+        self.read_ret = [b'123\n456', b'789\n', b'abcd']
         ret = self.expect.expect('a.*d')
         self.assertEqual(ret, 'abcd')
 
@@ -143,6 +144,6 @@ class TestSerialExpect(unittest.TestCase):
 
     def test_context_manager(self):
         with serial_expect.SerialExpect('TTY', 1234) as ser:
-            self.read_ret = ['123\n456', '789\n', 'abcd']
+            self.read_ret = [b'123\n456', b'789\n', b'abcd']
             ret = ser.expect('a.*d')
             self.assertEqual(ret, 'abcd')


### PR DESCRIPTION
Fix all encoding integration & autotests bugs with Python3 support.

Integration tests (fab nodes.test_gateway_code task) pass on Devgrenoble site (m3-17 & a8-17) with Yocto A8 target and:
* Yocto Krogoth version image
* [Yocto Dunfell version image](https://github.com/iot-lab/iot-lab-yocto/pull/39)

There is still Yocto RPI3 target support to be tested